### PR TITLE
MSPSDS-137: RAPEX case imports

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -2,5 +2,5 @@ class Activity < ApplicationRecord
   default_scope { order(created_at: :desc) }
   belongs_to :investigation
   belongs_to :activity_type
-  belongs_to :user
+  belongs_to :user, optional: true
 end

--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -33,7 +33,7 @@
   User
 </h4>
 <p>
-  <%= @activity.user.email %>
+  <%= @activity.user.nil? ? 'none' : @activity.user.email %>
 </p>
 
 <h4 class="heading-small">

--- a/lib/tasks/rapex_import.rake
+++ b/lib/tasks/rapex_import.rake
@@ -16,14 +16,13 @@ namespace :data_import do
     end
   end
 
+  # this will delete products even if they are used by an investigation not from RAPEX
   task delete_rapex: :environment do
-    pod_product_count = 9000
     RapexImport.all.destroy_all
-    pod_products = Product.last(pod_product_count)
-    Product.where.not(id: pod_products.collect(&:id)).destroy_all
-    InvestigationProduct.destroy_all
-    Investigation.destroy_all
-    Activity.destroy_all
+    Product.where(source: "Imported from RAPEX").destroy_all
+    destroyed_investigation_ids = Investigation.where(source: "Imported from RAPEX").destroy_all.collect(&:id)
+    InvestigationProduct.where(investigation_id: destroyed_investigation_ids).destroy_all
+    Activity.where(investigation_id: destroyed_investigation_ids).destroy_all
   end
 end
 

--- a/lib/tasks/rapex_import.rake
+++ b/lib/tasks/rapex_import.rake
@@ -44,7 +44,7 @@ end
 # TODO: add checking for existing products
 def create_product(notification)
   return false unless (name = name_or_product(notification))
-  Product.create(
+  Product.where.not(gtin: '').where(gtin: barcode_from_notification(notification)).first_or_create(
       gtin: barcode_from_notification(notification),
       name: name,
       description: field_from_notification(notification, "description"),

--- a/lib/tasks/rapex_import.rake
+++ b/lib/tasks/rapex_import.rake
@@ -79,7 +79,6 @@ def create_activity(notification, investigation, date)
   Activity.create(
       investigation_id: investigation.id,
       activity_type_id: ActivityType.find_by_name("notification").id,
-      user_id: User.first.id,  # TODO: probably change model user_id to source to prevent having to do this
       created_at: date,
       updated_at: date,
       notes: field_from_notification(notification, "measures")


### PR DESCRIPTION
Rake task now creates the products once if they have a barcode ('gtin').
The investigation and actions are generated from the RAPEX reports.
The data_import:delete_rapex task deletes the content generated by the data_import:rapex task.