### PR TITLE
MSPSDS-289: Fix prefix search and use fuzzy search for cases, businesses and products

### DIFF
--- a/app/controllers/investigations_controller.rb
+++ b/app/controllers/investigations_controller.rb
@@ -11,7 +11,7 @@ class InvestigationsController < ApplicationController
     @investigations = if params[:q].blank?
                         Investigation.paginate(page: params[:page], per_page: 20)
                       else
-                        Investigation.prefix_search(params[:q])
+                        Investigation.fuzzy_search(params[:q])
                                      .paginate(page: params[:page], per_page: 20)
                                      .records
                       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -37,7 +37,9 @@ class UsersController < ApplicationController
     if params[:q].blank?
       User.paginate(page: params[:page], per_page: 20)
     else
-      User.prefix_search(params[:q]).paginate(page: params[:page], per_page: 20).records
+      User.prefix_search(params[:q], :email)
+          .paginate(page: params[:page], per_page: 20)
+          .records
     end
   end
 end

--- a/app/helpers/businesses_helper.rb
+++ b/app/helpers/businesses_helper.rb
@@ -8,7 +8,7 @@ module BusinessesHelper
   end
 
   def search_for_businesses(page_size)
-    Business.prefix_search(params[:q])
+    Business.fuzzy_search(params[:q])
             .paginate(page: params[:page], per_page: page_size)
             .records
   end

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -23,7 +23,9 @@ module ProductsHelper
     if params[:q].blank?
       Product.paginate(page: params[:page], per_page: page_size)
     else
-      Product.prefix_search(params[:q]).paginate(page: params[:page], per_page: page_size).records
+      Product.fuzzy_search(params[:q])
+             .paginate(page: params[:page], per_page: page_size)
+             .records
     end
   end
 

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -7,21 +7,16 @@ module Searchable
 
     # "prefix" may be changed to a more appropriate query. For alternatives see:
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/term-level-queries.html
-    def self.prefix_search(query)
+    def self.prefix_search(query, field)
+      search_term = {}
+      search_term[field] = query.downcase # analyzer indexes records in lowercase
       __elasticsearch__.search(
-        # TODO-MSPSDS-298 Re-enable prefix search
-        # query: {
-        #   prefix: {
-        #     _all: {
-        #       value: query.downcase # analyzer indexes records in lowercase
-        #     }
-        #   }
-        # }
-        query
+        query: {
+          prefix: search_term
+        }
       )
     end
 
-    # "multi_match" searches across all fields, applying fuzzy matching to any text fields
     # "multi_match" searches across all fields, applying fuzzy matching to any text and keyword fields
     def self.fuzzy_search(query)
       __elasticsearch__.search(

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -20,5 +20,18 @@ module Searchable
         query
       )
     end
+
+    # "multi_match" searches across all fields, applying fuzzy matching to any text fields
+    # "multi_match" searches across all fields, applying fuzzy matching to any text and keyword fields
+    def self.fuzzy_search(query)
+      __elasticsearch__.search(
+        query: {
+          multi_match: {
+            query: query.downcase, # analyzer indexes records in lowercase
+            fuzziness: "AUTO"
+          }
+        }
+      )
+    end
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.2.3
     environment:
+      - xpack.security.enabled=false
       - "ES_JAVA_OPTS=-Xms750m -Xmx750m"
     volumes:
       - elasticsearch-volume:/usr/share/elasticsearch/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - postgres-volume:/var/lib/postgresql/data
   elasticsearch:
-    image: elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.2.3
     environment:
       - "ES_JAVA_OPTS=-Xms750m -Xmx750m"
     volumes:


### PR DESCRIPTION
This just uses the default fuzziness parameters for now, but should yield better search results when entering text phrases. We should look at adding n-gram or stemming indices if we want to further improve search results.

User email addresses are still searched using prefix matching.