### PR TITLE
MSPSDS-289: Use open source version of Elasticsearch Docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       context: .
       dockerfile: ./elasticsearch/Dockerfile
     environment:
-      - xpack.security.enabled=false
       - "ES_JAVA_OPTS=-Xms750m -Xmx750m"
     volumes:
       - elasticsearch-volume:/usr/share/elasticsearch/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       context: .
       dockerfile: ./elasticsearch/Dockerfile
     environment:
+      - "discovery.type=single-node"
       - "ES_JAVA_OPTS=-Xms750m -Xmx750m"
     volumes:
       - elasticsearch-volume:/usr/share/elasticsearch/data

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.2.3
+FROM docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.3
 
 RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu


### PR DESCRIPTION
This version does not come bundled with the commercial X-Pack plugin or trial licence.