### PR TITLE
MSPSDS-210: Specify fallback sort type when Elasticsearch index is empty

### DIFF
--- a/app/helpers/elasticsearch_query.rb
+++ b/app/helpers/elasticsearch_query.rb
@@ -52,7 +52,7 @@ private
   def sort_params
     sorting.map do |field, direction|
       {
-        "#{field}.sort": { order: direction }
+        "#{field}.sort": { order: direction, unmapped_type: "long" }
       }
     end
   end


### PR DESCRIPTION
This fixes an issue where sorting returns an error if a sort column is specified but no records are present in the Elasticsearch index (details [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html#_ignoring_unmapped_fields)).