### PR TITLE
Rename submodule to not start with a period

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "./keycloak/govuk-theme"]
+[submodule "keycloak/govuk-theme"]
 	path = keycloak/govuk-theme
 	url = https://github.com/UKGovernmentBEIS/keycloak-theme-govuk.git


### PR DESCRIPTION
GitHub doesn't deal well with submodule names that start with a period. In particular, it causes all calls to its [create tree API](https://developer.github.com/v3/git/trees/#create-a-tree) endpoint to 422 with a `GitRPC::BadGitmodules` error.

The name of a submodule is simply for convenience, so there shouldn't be any reason to prefer starting it with a period to not.