### PR TITLE
MSPSDS-654: Set timezone in configuration to fix bugged times

### DIFF
--- a/web/config/application.rb
+++ b/web/config/application.rb
@@ -22,5 +22,8 @@ module App
       html_tag
     }
     config.action_view.form_with_generates_ids = true
+
+    # This changes Rails timezone, but keeps ActiveRecord in UTC
+    config.time_zone = "Europe/London"
   end
 end


### PR DESCRIPTION
Should not change how timestamps are stored in database according to documentation, but will change the way Rails treats them. In particular it fixes the annoying bug with history being 1 hour early. 