### PR TITLE
MSPSDS-723: Make sure each activity causes an update of its investigation

### DIFF
--- a/web/app/models/activity.rb
+++ b/web/app/models/activity.rb
@@ -3,7 +3,7 @@ class Activity < ApplicationRecord
     include UserService
   end
 
-  belongs_to :investigation
+  belongs_to :investigation, touch: true
 
   has_one :source, as: :sourceable, dependent: :destroy
 


### PR DESCRIPTION
As I wrote on the ticket, case is not ‘updated’ when we update something that can be associated with many cases, like a product or a business. ￼￼

Case is ’updated’ when we change a field, associate/disassociate anything with a case. That probably also includes changing anything that can only be associated to a single case, like hazard details, description of an image linked to a case, adding case correspondence, etc.

Ed and Nick agree this is a reasonable approach, and that if for some reason it is not, then we can add a ticket for it later. 

Thing is, this parallels our conditions for creating an activity. And in general I think we do want to update a case whenever it has a new activity in its timeline, and I can't think of any reason to change 'updated date' without adding a point to a timeline. 