### PR TITLE
MSPSDS-537: Filter by status

### DIFF
--- a/web/app/helpers/investigations_helper.rb
+++ b/web/app/helpers/investigations_helper.rb
@@ -30,7 +30,7 @@ module InvestigationsHelper
 
   def query_params
     set_default_status_filter
-    params.permit(:q, :sort, :direction, :status_open, :status_closed)
+    params.permit(:q, :sort, :direction, :status_open, :status_closed, :page)
   end
 
   def set_default_status_filter

--- a/web/app/views/investigations/index.xlsx.axlsx
+++ b/web/app/views/investigations/index.xlsx.axlsx
@@ -6,7 +6,7 @@ book.add_worksheet name: "Cases" do |sheet_investigations|
 
   @investigations.each do |investigation|
     sheet_investigations.add_row [
-      investigation.id,
+      investigation.pretty_id,
       investigation.is_closed? ? "Closed" : "Open",
       investigation.title,
       investigation.description,
@@ -79,7 +79,7 @@ book.add_worksheet name: "Actions" do |sheet_actions|
         activity.id,
         activity.type.titleize,
         activity.body,
-        activity.source.show,
+        activity.source&.show,
         investigation.id
       ]
     end


### PR DESCRIPTION
Probably not really related to status, but it's the ticket this bug report showed up.

Pagination was broken when exporting to xlsx. This makes sure that 'the exported list is exactly as visible list', which might not be the perfectly intuitive approach, but is what is written on several tickets. 