### PR TITLE
MSPSDS-enum-bugfix: Hopefully fix int crashes

### DIFF
--- a/web/app/models/investigation.rb
+++ b/web/app/models/investigation.rb
@@ -5,7 +5,7 @@ class Investigation < ApplicationRecord
 
   attr_accessor :priority_rationale, :status_rationale
 
-  enum priority: %i[low medium high]
+  enum priority: %i[low medium high], _suffix: true
 
   validates :question_title, presence: true, on: :question_details
   validate :validate_assignment, :validate_priority


### PR DESCRIPTION
I couldn't replicate the crash on build or up that's happening on int, bug message was 

"raise_conflict_error': You tried to define an enum named "priority" on the model "Investigation", but this will generate a instance method "low?", which is already defined by another enum. (ArgumentError)"

This should fix this particular error, because it now won't try to create method called "low", rather it will use "low_priority", which is hopefully unique. But like I said, I couldn't actually replicate it so there might be some problems further down the build line? 