### PR TITLE
MSPSDS-744: Fix accessible autocomplete styling

### DIFF
--- a/web/app/assets/stylesheets/application.css
+++ b/web/app/assets/stylesheets/application.css
@@ -11,7 +11,7 @@
  * It is generally better to create a new file per style scope.
  *
  *= require_self
- *= require main
  *= require govuk-country-and-territory-autocomplete/dist/location-autocomplete.min.css
  *= require accessible-autocomplete/dist/accessible-autocomplete.min.css
+ *= require main
  */

--- a/web/app/assets/stylesheets/autocomplete.scss
+++ b/web/app/assets/stylesheets/autocomplete.scss
@@ -44,7 +44,7 @@
 }
 
 .autocomplete__dropdown-arrow-down {
-  z-index: -1;
+  z-index: auto;
   display: inline-block;
   position: absolute;
   right: 8px;
@@ -62,7 +62,7 @@
   max-height: 332px;
   overflow-x: hidden;
   padding: 0;
-  width: calc(100% - 4px);
+  width: 100%;
 }
 
 .autocomplete__menu--visible {
@@ -90,7 +90,8 @@
   border-width: 1px 0;
   cursor: pointer;
   display: block;
-  height: 26px;
+  height: auto;
+  min-height: 36px;
   line-height: 26px;
   position: relative;
 }


### PR DESCRIPTION
Ensure that our styling overrides take precedence over the module stylesheet by switching the order in which they are imported.