### PR TITLE
MSPSDS-551: Investigation business and product sort fix

### DIFF
--- a/web/app/models/investigation.rb
+++ b/web/app/models/investigation.rb
@@ -27,12 +27,12 @@ class Investigation < ApplicationRecord
   belongs_to_active_hash :assignee, class_name: "User", optional: true
 
   has_many :investigation_products, dependent: :destroy
-  has_many :products, -> { unscope(:order).order("investigation_products.created_at") }, through: :investigation_products,
+  has_many :products, through: :investigation_products,
            after_add: :create_audit_activity_for_product,
            after_remove: :create_audit_activity_for_removing_product
 
   has_many :investigation_businesses, dependent: :destroy
-  has_many :businesses, -> { unscope(:order).order("investigation_businesses.created_at") }, through: :investigation_businesses,
+  has_many :businesses, through: :investigation_businesses,
            after_add: :create_audit_activity_for_business,
            after_remove: :create_audit_activity_for_removing_business
 

--- a/web/app/models/investigation_business.rb
+++ b/web/app/models/investigation_business.rb
@@ -3,4 +3,6 @@ class InvestigationBusiness < ApplicationRecord
   belongs_to :business
   # TODO MSPSDS-687 Give these relationships a way to be set
   enum relationship: %i[manufacturer distributor importer]
+
+  default_scope { order('created_at') }
 end

--- a/web/app/models/investigation_product.rb
+++ b/web/app/models/investigation_product.rb
@@ -1,4 +1,6 @@
 class InvestigationProduct < ApplicationRecord
   belongs_to :investigation
   belongs_to :product
+
+  default_scope { order('created_at') }
 end


### PR DESCRIPTION
The was an error on startup with the `.order("investigation_products.created_at")`:
```
2018-11-26T08:06:18.26+0000 [APP/PROC/WEB/0] ERR /home/vcap/deps/0/vendor_bundle/ruby/2.4.0/gems/activerecord-5.2.1/lib/active_record/connection_adapters/postgresql_adapter.rb:603:in `async_exec': PG::UndefinedColumn: ERROR:  column investigation_businesses.created_at does not exist (ActiveRecord::StatementInvalid)
```

which was coming from the elasticsearch import at the bottom of `web/config/environments/production.rb`.

Seems related to https://stackoverflow.com/questions/40247388/rails-5-has-many-through-order-on-through-table. I don't actually know if this still produces the required functionality but it at least fixes the deployment!