### PR TITLE
MSPSDS-538: Exclude partial matches when a full match for pretty_id exists

### DIFF
--- a/web/app/helpers/elasticsearch_query.rb
+++ b/web/app/helpers/elasticsearch_query.rb
@@ -84,7 +84,7 @@ private
       multi_match: {
         query: query,
         fields: @exact_fields,
-        fuzziness: 0
+        type: "phrase"
       }
     }
   end


### PR DESCRIPTION
Tiny change so that something like "0002-xxxx" does not return "0002-yyyy" anymore. 