### PR TITLE
MSPSDS-NONE: Test fixes for Elasticsearch failures

### DIFF
--- a/web/test/controllers/businesses_controller_test.rb
+++ b/web/test/controllers/businesses_controller_test.rb
@@ -7,7 +7,7 @@ class BusinessesControllerTest < ActionDispatch::IntegrationTest
     @business_two = businesses(:two)
     @business_one.source = sources(:business_one)
     @business_two.source = sources(:business_two)
-    Business.import force: true
+    Business.import refresh: true
     allow(CompaniesHouseClient.instance).to receive(:companies_house_businesses).and_return([])
   end
 

--- a/web/test/controllers/investigations/businesses_controller_test.rb
+++ b/web/test/controllers/investigations/businesses_controller_test.rb
@@ -6,7 +6,7 @@ class Investigations::BusinessesControllerTest < ActionDispatch::IntegrationTest
     @investigation = investigations(:one)
     @business = businesses(:one)
     @business.source = sources(:business_one)
-    Business.import force: true
+    Business.import refresh: true
     allow(CompaniesHouseClient.instance).to receive(:companies_house_businesses).and_return([])
   end
 

--- a/web/test/controllers/investigations/products_controller_test.rb
+++ b/web/test/controllers/investigations/products_controller_test.rb
@@ -7,7 +7,6 @@ class Investigations::ProductsControllerTest < ActionDispatch::IntegrationTest
     @investigation.source = sources(:investigation_one)
     @product = products(:iphone)
     @product.source = sources(:product_iphone)
-    Product.import force: true
   end
 
   teardown do

--- a/web/test/controllers/investigations_controller_test.rb
+++ b/web/test/controllers/investigations_controller_test.rb
@@ -3,24 +3,29 @@ require "test_helper"
 class InvestigationsControllerTest < ActionDispatch::IntegrationTest
   setup do
     sign_in_as_admin
-    @investigation_one = investigations(:one)
-    @investigation_two = investigations(:two)
-    @investigation_three = investigations(:three)
-    @investigation_no_products = investigations(:no_products)
-    @investigation_one.source = sources(:investigation_one)
 
     User.all
+
+    @investigation_one = investigations(:one)
+    @investigation_one.created_at = Time.zone.parse('2014-07-11 21:00')
     @investigation_one.assignee = User.find_by(last_name: "Admin")
+    @investigation_one.source = sources(:investigation_one)
     @investigation_one.save
+
+    @investigation_two = investigations(:two)
+    @investigation_two.created_at = Time.zone.parse('2015-07-11 21:00')
     @investigation_two.assignee = User.find_by(last_name: "User")
     @investigation_two.save
 
-    @investigation_one.created_at = Time.zone.parse('2014-07-11 21:00')
+    @investigation_three = investigations(:three)
+    @investigation_no_products = investigations(:no_products)
+
+    # The updated_at values must be set separately in order to be respected
     @investigation_one.updated_at = Time.zone.parse('2017-07-11 21:00')
     @investigation_one.save
-    @investigation_two.created_at = Time.zone.parse('2015-07-11 21:00')
     @investigation_two.updated_at = Time.zone.parse('2016-07-11 21:00')
     @investigation_two.save
+
     Investigation.import refresh: true
   end
 

--- a/web/test/controllers/investigations_controller_test.rb
+++ b/web/test/controllers/investigations_controller_test.rb
@@ -4,8 +4,6 @@ class InvestigationsControllerTest < ActionDispatch::IntegrationTest
   setup do
     sign_in_as_admin
 
-    User.all
-
     @investigation_one = investigations(:one)
     @investigation_one.created_at = Time.zone.parse('2014-07-11 21:00')
     @investigation_one.assignee = User.find_by(last_name: "Admin")

--- a/web/test/controllers/investigations_controller_test.rb
+++ b/web/test/controllers/investigations_controller_test.rb
@@ -21,7 +21,7 @@ class InvestigationsControllerTest < ActionDispatch::IntegrationTest
     @investigation_two.created_at = Time.zone.parse('2015-07-11 21:00')
     @investigation_two.updated_at = Time.zone.parse('2016-07-11 21:00')
     @investigation_two.save
-    Investigation.import force: true
+    Investigation.import refresh: true
   end
 
   teardown do

--- a/web/test/controllers/products_controller_test.rb
+++ b/web/test/controllers/products_controller_test.rb
@@ -7,7 +7,7 @@ class ProductsControllerTest < ActionDispatch::IntegrationTest
     @product_one.source = sources(:product_one)
     @product_iphone = products(:iphone)
     @product_iphone.source = sources(:product_iphone)
-    Product.import force: true
+
     test_image1 = Rails.root.join('test', 'fixtures', 'files', 'testImage.png')
     test_image2 = Rails.root.join('test', 'fixtures', 'files', 'testImage2.png')
     @product_one.images.attach(io: File.open(test_image1), filename: 'testImage.png')

--- a/web/test/helpers/product_helper_test.rb
+++ b/web/test/helpers/product_helper_test.rb
@@ -10,7 +10,6 @@ class ProductHelperTest < ActiveSupport::TestCase
     @iphone_3g = products(:iphone_3g)
     @pixel = products(:pixel)
     @chromecast = products(:chromecast)
-    Product.import refresh: true, force: true
   end
 
   test "product search matches by name (fuzzy)" do

--- a/web/test/helpers/product_helper_test.rb
+++ b/web/test/helpers/product_helper_test.rb
@@ -18,10 +18,10 @@ class ProductHelperTest < ActiveSupport::TestCase
     results = advanced_product_search(search_model)
 
     # Assert
-    assert_includes(results, @iphone)
-    assert_includes(results, @iphone_3g)
-    assert_not_includes(results, @pixel)
-    assert_not_includes(results, @chromecast)
+    assert_results_include(results, @iphone)
+    assert_results_include(results, @iphone_3g)
+    assert_results_do_not_include(results, @pixel)
+    assert_results_do_not_include(results, @chromecast)
   end
 
   test "product search matches by product type (fuzzy)" do
@@ -30,10 +30,10 @@ class ProductHelperTest < ActiveSupport::TestCase
     results = advanced_product_search(search_model)
 
     # Assert
-    assert_includes(results, @iphone)
-    assert_includes(results, @iphone_3g)
-    assert_includes(results, @pixel)
-    assert_not_includes(results, @chromecast)
+    assert_results_include(results, @iphone)
+    assert_results_include(results, @iphone_3g)
+    assert_results_include(results, @pixel)
+    assert_results_do_not_include(results, @chromecast)
   end
 
   test "product search matches by brand (fuzzy)" do
@@ -42,10 +42,10 @@ class ProductHelperTest < ActiveSupport::TestCase
     results = advanced_product_search(search_model)
 
     # Assert
-    assert_includes(results, @pixel)
-    assert_includes(results, @chromecast)
-    assert_not_includes(results, @iphone)
-    assert_not_includes(results, @iphone_3g)
+    assert_results_include(results, @pixel)
+    assert_results_include(results, @chromecast)
+    assert_results_do_not_include(results, @iphone)
+    assert_results_do_not_include(results, @iphone_3g)
   end
 
   test "product search matches if at least one field matches, prioritising higher scores" do
@@ -54,8 +54,8 @@ class ProductHelperTest < ActiveSupport::TestCase
     results = advanced_product_search(search_model)
 
     # Assert
-    assert_includes(results, @chromecast)
-    assert_includes(results, @pixel)
+    assert_results_include(results, @chromecast)
+    assert_results_include(results, @pixel)
     results.find_index(@chromecast) < results.find_index(@pixel)
   end
 
@@ -65,8 +65,8 @@ class ProductHelperTest < ActiveSupport::TestCase
     results = advanced_product_search(search_model)
 
     # Assert
-    assert_not_includes(results, @iphone)
-    assert_not_includes(results, @iphone_3g)
+    assert_results_do_not_include(results, @iphone)
+    assert_results_do_not_include(results, @iphone_3g)
   end
 
   test "product search excludes specified ids" do
@@ -75,7 +75,15 @@ class ProductHelperTest < ActiveSupport::TestCase
     results = advanced_product_search(search_model, [@pixel.id])
 
     # Assert
-    assert_not_includes(results, @pixel)
-    assert_includes(results, @chromecast)
+    assert_results_do_not_include(results, @pixel)
+    assert_results_include(results, @chromecast)
+  end
+
+  def assert_results_include(results, product)
+    assert_includes(results.map(&:name), product.name)
+  end
+
+  def assert_results_do_not_include(results, product)
+    assert_not_includes(results.map(&:name), product.name)
   end
 end

--- a/web/test/models/investigation_test.rb
+++ b/web/test/models/investigation_test.rb
@@ -5,7 +5,6 @@ class InvestigationTest < ActiveSupport::TestCase
     sign_in_as_user
     @investigation = investigations(:search_related_products)
     @product = products(:iphone)
-    Investigation.import force: true
   end
 
   teardown do

--- a/web/test/system/investigation_assignee_test.rb
+++ b/web/test/system/investigation_assignee_test.rb
@@ -1,10 +1,9 @@
 require "application_system_test_case"
 
-class InvestigationIAssigneeTest < ApplicationSystemTestCase
+class InvestigationAssigneeTest < ApplicationSystemTestCase
   setup do
     sign_in_as_user
     visit assign_investigation_path(investigations(:one))
-    Investigation.import force: true
   end
 
   teardown do

--- a/web/test/system/investigation_highlight_test.rb
+++ b/web/test/system/investigation_highlight_test.rb
@@ -4,7 +4,6 @@ class InvestigationHighlightTest < ApplicationSystemTestCase
   setup do
     sign_in_as_user
     visit root_path
-    Investigation.import force: true
   end
 
   teardown do

--- a/web/test/test_helper.rb
+++ b/web/test/test_helper.rb
@@ -19,6 +19,22 @@ class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 
+  # Import all relevant models into Elasticsearch
+  def self.import_into_elasticsearch
+    unless @models_imported
+      ActiveRecord::Base.descendants.each do |model|
+        if model.respond_to?(:__elasticsearch__)
+          model.import force: true, refresh: true
+        end
+      end
+      @models_imported = true
+    end
+  end
+
+  def setup
+    self.class.import_into_elasticsearch
+  end
+
   # Add more helper methods to be used by all tests here...
   def sign_in_as_admin
     admin = admin_user

--- a/web/test/test_helper.rb
+++ b/web/test/test_helper.rb
@@ -85,6 +85,7 @@ private
 
   def stub_user_data(users:)
     allow(Keycloak::Internal).to receive(:get_users).and_return(format_user_for_get_users(users))
+    User.all
   end
 
   def format_user_for_get_users(users)

--- a/web/test/test_helper.rb
+++ b/web/test/test_helper.rb
@@ -39,15 +39,15 @@ class ActiveSupport::TestCase
   def sign_in_as_admin
     admin = admin_user
     stub_user_credentials(user: admin, is_admin: true)
-    stub_client_config
     stub_user_data(users: [admin, test_user])
+    stub_client_config
   end
 
   def sign_in_as_user
     user = test_user
     stub_user_credentials(user: user, is_admin: false)
-    stub_client_config
     stub_user_data(users: [admin_user, user])
+    stub_client_config
   end
 
   def logout
@@ -56,9 +56,7 @@ class ActiveSupport::TestCase
     allow(Keycloak::Client).to receive(:has_role?).and_call_original
     allow(Keycloak::Client).to receive(:auth_server_url).and_call_original
 
-    allow(Keycloak::Internal).to receive(:all_users).and_call_original
-
-    Rails.cache.delete(:keycloak_users)
+    reset_user_data
   end
 
 private
@@ -91,5 +89,10 @@ private
 
   def format_user_for_get_users(users)
     users.map { |user| { id: user[:id], email: user[:email], firstName: user[:first_name], lastName: user[:last_name] } }.to_json
+  end
+
+  def reset_user_data
+    allow(Keycloak::Internal).to receive(:get_users).and_call_original
+    Rails.cache.delete(:keycloak_users)
   end
 end


### PR DESCRIPTION
To resolve some of the more common Elasticsearch-related errors we've been seeing in recent test runs, this PR makes the following changes:

* Import all test fixtures into Elasticsearch at the start of each test class
* Remove redundant Elasticsearch imports in tests
* Where imports are still required, refresh the index instead of recreating it
* Ensure all stubbed users are loaded as part of relevant test helper methods
* Minor refactoring of some test setup and assertions