### PR TITLE
MSPSDS-722: Restyle search box and case list

### DIFF
--- a/web/app/assets/stylesheets/search-box.scss
+++ b/web/app/assets/stylesheets/search-box.scss
@@ -16,5 +16,6 @@
     background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 36 36' width='40' height='40'%3E%3Cpath d='M25.7 24.8L21.9 21c.7-1 1.1-2.2 1.1-3.5 0-3.6-2.9-6.5-6.5-6.5S10 13.9 10 17.5s2.9 6.5 6.5 6.5c1.6 0 3-.6 4.1-1.5l3.7 3.7 1.4-1.4zM12 17.5c0-2.5 2-4.5 4.5-4.5s4.5 2 4.5 4.5-2 4.5-4.5 4.5-4.5-2-4.5-4.5z' fill='white'%3E%3C/path%3E%3C/svg%3E") $govuk-link-colour no-repeat top left;
 
     border: 0;
+    cursor: pointer;
   }
 }

--- a/web/app/views/investigations/index.html.slim
+++ b/web/app/views/investigations/index.html.slim
@@ -2,77 +2,82 @@
 - content_for :after_header do
   = render "layouts/navbar"
 
-main#main-content.govuk-main-wrapper role="main"
-  .govuk-grid-row
-    .govuk-grid-column-two-thirds
-      h1.govuk-heading-xl
-        | Cases
-  .govuk-grid-row
-    .govuk-grid-column-one-quarter class="govuk-!-margin-bottom-2"
-      div class="govuk-!-margin-bottom-0"
-        = form_with(model: @search, scope: "", url: investigations_path, method: :get,
-                class: "mspsds-search") do |form|
-          .mspsds-search-box
-            = form.label "Keywords", class: "govuk-label--s"
-            = form.text_field :q, class: "govuk-input"
-            = form.submit "Search", name: nil, class: "mspsds-search-box--submit"
-          hr.govuk-section-break.govuk-section-break--m.govuk-section-break--visible
-          .govuk-form-group
-            fieldset.govuk-fieldset
-              legend.govuk-fieldset__legend--s
-                | Assigned to
-              .govuk-checkboxes data-module="checkboxes"
-                .govuk-checkboxes__item
-                  = form.check_box :assigned_to_me, { class: "govuk-checkboxes__input" }, "checked", "unchecked"
-                  = form.label :assigned_to_me, "Me", class: "govuk-checkboxes__label"
-                .govuk-checkboxes__item
-                  = form.check_box :assigned_to_someone_else, { class: "govuk-checkboxes__input",
-                          "data-aria-controls": "conditional-other-assignee" }, "checked", "unchecked"
-                  = form.label :assigned_to_someone_else, "Someone else", class: "govuk-checkboxes__label"
-                #conditional-other-assignee.govuk-checkboxes__conditional.govuk-checkboxes__conditional--hidden
-                  = form.label :assigned_to_someone_else_id, "Name", class: "govuk-label"
-                  = form.select :assigned_to_someone_else_id,
-                          User.get_assignees_select_options_short([current_user]),
-                          {},
-                          class: "govuk-select", id: "assignee-picker"
-          .govuk-form-group
-            fieldset.govuk-fieldset
-              .govuk-fieldset__legend--s
-                | Status
-              .govuk-checkboxes
-                .govuk-checkboxes__item
-                  = form.check_box :status_open, { class: "govuk-checkboxes__input" }, "checked", "unchecked"
-                  = form.label :status_open, "Open", class: "govuk-checkboxes__label"
-                .govuk-checkboxes__item
-                  = form.check_box :status_closed, { class: "govuk-checkboxes__input" }, "checked", "unchecked"
-                  = form.label :status_closed, "Closed", class: "govuk-checkboxes__label"
-          .govuk-form-group
-            fieldset.govuk-fieldset
-              .govuk-fieldset__legend--s
-                | Sort by
-              .govuk-radios class="govuk-!-margin-bottom-5"
-                .govuk-radios__item
-                  = form.radio_button :sort_by, "recent", class: "govuk-radios__input"
-                  = form.label :sort_by, "Updated: recent", class: "govuk-radios__label"
-                .govuk-radios__item
-                  = form.radio_button :sort_by, "oldest", class: "govuk-radios__input"
-                  = form.label :sort_by, "Updated: oldest", class: "govuk-radios__label"
-                .govuk-radios__item
-                  = form.radio_button :sort_by, "newest", class: "govuk-radios__input"
-                  = form.label :sort_by, "Created: newest", class: "govuk-radios__label"
-          = form.submit "Apply filters", name: nil, class: "govuk-button"
-
-    .govuk-grid-column-three-quarters
-      p
-        /TODO remove the links below
-        = link_to "Report an unsafe product", new_report_path, class: "govuk-link mspsds-block-link"
-        = link_to "Begin a case", new_investigation_path, class: "govuk-link mspsds-block-link"
-        = link_to "Ask a question", new_question_path, class: "govuk-link mspsds-block-link"
-
-      - if @results.any?
-        = render "table", search_results: @results
-        = will_paginate @investigations
-        br
-        = link_to "Export as spreadsheet", investigations_path(format: :xlsx, params: query_params)
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    h1.govuk-heading-xl
+      - if params[:q].present?
+        span.govuk-caption-xl = "Case search results"
+        = params[:q]
+        span.govuk-caption-m = "#{@results.count} #{'result'.pluralize(@results.count)}"
       - else
-        .govuk-heading-xl[style="text-align:center"] = "No results"
+        = "Cases"
+
+.govuk-grid-row
+  .govuk-grid-column-one-quarter class="govuk-!-margin-bottom-2"
+    div class="govuk-!-margin-bottom-0"
+      = form_with(model: @search, scope: "", url: investigations_path, method: :get,
+              class: "mspsds-search") do |form|
+        .mspsds-search-box
+          = form.label "Keywords", class: "govuk-label--s"
+          = form.text_field :q, class: "govuk-input"
+          = form.submit "Search", name: nil, class: "mspsds-search-box--submit"
+        hr.govuk-section-break.govuk-section-break--m.govuk-section-break--visible
+        .govuk-form-group
+          fieldset.govuk-fieldset
+            legend.govuk-fieldset__legend--s
+              | Assigned to
+            .govuk-checkboxes data-module="checkboxes"
+              .govuk-checkboxes__item
+                = form.check_box :assigned_to_me, { class: "govuk-checkboxes__input" }, "checked", "unchecked"
+                = form.label :assigned_to_me, "Me", class: "govuk-checkboxes__label"
+              .govuk-checkboxes__item
+                = form.check_box :assigned_to_someone_else, { class: "govuk-checkboxes__input",
+                        "data-aria-controls": "conditional-other-assignee" }, "checked", "unchecked"
+                = form.label :assigned_to_someone_else, "Someone else", class: "govuk-checkboxes__label"
+              #conditional-other-assignee.govuk-checkboxes__conditional.govuk-checkboxes__conditional--hidden
+                = form.label :assigned_to_someone_else_id, "Name", class: "govuk-label"
+                = form.select :assigned_to_someone_else_id,
+                        User.get_assignees_select_options_short([current_user]),
+                        {},
+                        class: "govuk-select", id: "assignee-picker"
+        .govuk-form-group
+          fieldset.govuk-fieldset
+            .govuk-fieldset__legend--s
+              | Status
+            .govuk-checkboxes
+              .govuk-checkboxes__item
+                = form.check_box :status_open, { class: "govuk-checkboxes__input" }, "checked", "unchecked"
+                = form.label :status_open, "Open", class: "govuk-checkboxes__label"
+              .govuk-checkboxes__item
+                = form.check_box :status_closed, { class: "govuk-checkboxes__input" }, "checked", "unchecked"
+                = form.label :status_closed, "Closed", class: "govuk-checkboxes__label"
+        .govuk-form-group
+          fieldset.govuk-fieldset
+            .govuk-fieldset__legend--s
+              | Sort by
+            .govuk-radios class="govuk-!-margin-bottom-5"
+              .govuk-radios__item
+                = form.radio_button :sort_by, "recent", class: "govuk-radios__input"
+                = form.label :sort_by, "Updated: recent", class: "govuk-radios__label"
+              .govuk-radios__item
+                = form.radio_button :sort_by, "oldest", class: "govuk-radios__input"
+                = form.label :sort_by, "Updated: oldest", class: "govuk-radios__label"
+              .govuk-radios__item
+                = form.radio_button :sort_by, "newest", class: "govuk-radios__input"
+                = form.label :sort_by, "Created: newest", class: "govuk-radios__label"
+        = form.submit "Apply filters", name: nil, class: "govuk-button"
+
+  .govuk-grid-column-three-quarters
+    p
+      /TODO remove the links below
+      = link_to "Report an unsafe product", new_report_path, class: "govuk-link mspsds-block-link"
+      = link_to "Begin a case", new_investigation_path, class: "govuk-link mspsds-block-link"
+      = link_to "Ask a question", new_question_path, class: "govuk-link mspsds-block-link"
+
+    - if @results.any?
+      = render "table", search_results: @results
+      = will_paginate @investigations
+      br
+      = link_to "Export as spreadsheet", investigations_path(format: :xlsx, params: query_params)
+    - else
+      .govuk-heading-xl[style="text-align:center"] = "No results"

--- a/web/config/initializers/sidekiq.rb
+++ b/web/config/initializers/sidekiq.rb
@@ -1,12 +1,3 @@
-Sidekiq.configure_server do |config|
-  config.redis = Rails.application.config_for(:redis)
-  remove_empty_attachments_job
-end
-
-Sidekiq.configure_client do |config|
-  config.redis = Rails.application.config_for(:redis)
-end
-
 def remove_empty_attachments_job
   remove_attachments_job = Sidekiq::Cron::Job.new(
     name: 'remove attachments pointing at nothing, midnight every day',
@@ -17,4 +8,13 @@ def remove_empty_attachments_job
     Rails.logger.error "***** WARNING - Removing empty attachments was not saved! *****"
     Rails.logger.error remove_attachments_job.errors
   end
+end
+
+Sidekiq.configure_server do |config|
+  config.redis = Rails.application.config_for(:redis)
+  remove_empty_attachments_job
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = Rails.application.config_for(:redis)
 end


### PR DESCRIPTION
Tiny changes after it came back from testing. 

Although ticket suggests the code is shared between case list page and business/product lists, it's actually separate(just used to be very similar). Which is probably good, cause designs for them look differently. 

Includes a trivial change to sidekiq(moving method so it's loaded in time for ruby to know it's there). 