### PR TITLE
COS-31: Fix dependabot issues

### DIFF
--- a/cosmetics-web/vendor/shared-web/lib/shared/web/version.rb
+++ b/cosmetics-web/vendor/shared-web/lib/shared/web/version.rb
@@ -1,0 +1,1 @@
+../../../../../../shared-web/lib/shared/web/version.rb

--- a/cosmetics-web/vendor/shared-web/package.json
+++ b/cosmetics-web/vendor/shared-web/package.json
@@ -1,0 +1,1 @@
+../../../shared-web/package.json

--- a/cosmetics-web/vendor/shared-web/shared-web.gemspec
+++ b/cosmetics-web/vendor/shared-web/shared-web.gemspec
@@ -1,0 +1,1 @@
+../../../shared-web/shared-web.gemspec

--- a/web/vendor/shared-web/lib/shared/web/version.rb
+++ b/web/vendor/shared-web/lib/shared/web/version.rb
@@ -1,0 +1,1 @@
+../../../../../../shared-web/lib/shared/web/version.rb

--- a/web/vendor/shared-web/package.json
+++ b/web/vendor/shared-web/package.json
@@ -1,0 +1,1 @@
+../../../shared-web/package.json

--- a/web/vendor/shared-web/shared-web.gemspec
+++ b/web/vendor/shared-web/shared-web.gemspec
@@ -1,0 +1,1 @@
+../../../shared-web/shared-web.gemspec


### PR DESCRIPTION
It's currently complaining that it can't find `shared-web` https://app.dependabot.com/accounts/UKGovernmentBEIS/#beis-mspsds

Adding these symlinks allows me to run `bundle install` and `yarn install` on my host machine.

Might be worth checking that this doesn't totally break someone on Windows? @jasiekmiko, @raamSoftwire?