### PR TITLE
MSPSDS-NONE: Fix Cloud Foundry deployment by removing existing files

### DIFF
--- a/cosmetics-web/deploy.sh
+++ b/cosmetics-web/deploy.sh
@@ -10,6 +10,7 @@ set -ex
 # SPACE: the space to which you want to deploy
 # If NO_START is set the app won't be started
 
+rm -fr ./cosmetics-web/vendor/shared-web/
 cp -a ./shared-web/. ./cosmetics-web/vendor/shared-web/
 
 if [[ -z ${NO_START} ]] ; then

--- a/web/deploy.sh
+++ b/web/deploy.sh
@@ -10,6 +10,7 @@ set -ex
 # SPACE: the space to which you want to deploy
 # If NO_START is set the app won't be started
 
+rm -fr ./web/vendor/shared-web/
 cp -a ./shared-web/. ./web/vendor/shared-web/
 
 if [[ -z ${NO_START} ]] ; then

--- a/worker/deploy.sh
+++ b/worker/deploy.sh
@@ -19,6 +19,7 @@ cp ./worker/apt.yml ./web/apt.yml
 # Copy the clamav configuration
 cp -a ./worker/clamav/. ./web/clamav/
 
+rm -fr ./web/vendor/shared-web/
 cp -a ./shared-web/. ./web/vendor/shared-web/
 
 if [[ -z ${NO_START} ]] ; then


### PR DESCRIPTION
PR #392 added symlink files to the shared-web subdirectories of cosmetics-web and web to allow bundler and yarn to find the relevant files from shared-web. These existing files cause the deploy scripts to fail when copying the contents of shared-web to these subdirectories, so remove them first.