### PR TITLE
Revert Keycloak upgrade

### DIFF
--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -5,10 +5,8 @@ WORKDIR /tmp/keycloak
 RUN mkdir -p ./artifacts
 RUN mkdir -p ./package
 
-ENV keycloakVersion 4.7.0
-
 # Download and unpack Keycloak
-RUN curl -Lo ./artifacts/keycloak.tar.gz https://downloads.jboss.org/keycloak/$keycloakVersion.Final/keycloak-$keycloakVersion.Final.tar.gz
+RUN curl -Lo ./artifacts/keycloak.tar.gz https://downloads.jboss.org/keycloak/4.3.0.Final/keycloak-4.3.0.Final.tar.gz
 RUN tar -xzf ./artifacts/keycloak.tar.gz --directory ./package --strip 1
 
 # Download and add PostgreSQL JDBC driver

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -106,24 +106,3 @@ Allow keycloak to redirect back to the app after login
 Follow the steps in [the SMS autheticator README's Configuration section](
 ./providers/sms-authenticator/README.md#Configuration) to enable SMS two factor authentication. Set the 2FA 
 code length to 6.
-
-### Troubleshooting
-##### Problem: the keycloak database doesn't exist when running `$ docker-compose up`
-Error message:
-```
-WARN  [org.jboss.jca.core.connectionmanager.pool.strategy.OnePool] (ServerService Thread Pool -- 52) IJ000604: Throwable while attempting to get a new connection: null: javax.resource.ResourceException: IJ031084: Unable to create connection
-[......]
-Caused by: org.postgresql.util.PSQLException: FATAL: database "keycloak" does not exist
-```
-
-The first time `$ docker-compose up` is run in the root directory, a keycloak database is created according to 
-`/postgres/setup-keycloak.sh`. This database shares a docker volume with the dev database.
-
-If the local keycloak database is subsequently dropped but the development database is not, then this script will not 
-run the next time you run `$ docker-compose up`.
-
-To recreate the database, start the postgres command line with
-
-```$ docker-compose exec postgres --username keycloak```
-
-then in the postgres interface run each command from `/postgres/setup-keycloak.sh`.

--- a/keycloak/configuration/initial-setup.json
+++ b/keycloak/configuration/initial-setup.json
@@ -1554,7 +1554,7 @@
     "offlineSessionMaxLifespanEnabled" : "false",
     "waitIncrementSeconds" : "60"
   },
-  "keycloakVersion" : "4.7.0.Final",
+  "keycloakVersion" : "4.3.0.Final",
   "userManagedAccessAllowed" : false
 }, {
   "id" : "master",
@@ -2995,6 +2995,6 @@
     "offlineSessionMaxLifespanEnabled" : "false",
     "waitIncrementSeconds" : "60"
   },
-  "keycloakVersion" : "4.7.0.Final",
+  "keycloakVersion" : "4.3.0.Final",
   "userManagedAccessAllowed" : false
 } ]

--- a/keycloak/providers/email/pom.xml
+++ b/keycloak/providers/email/pom.xml
@@ -14,19 +14,19 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
-            <version>4.7.0.Final</version>
+            <version>4.3.0.Final</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi</artifactId>
-            <version>4.7.0.Final</version>
+            <version>4.3.0.Final</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi-private</artifactId>
-            <version>4.7.0.Final</version>
+            <version>4.3.0.Final</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Reverts UKGovernmentBEIS/beis-mspsds#393

An issue with the latest release of Keycloak breaks our ability to fetch users from MSPSDS (the exact cause is still TBD, but seems related to a permissions issue for calls to the Keycloak API when using client credentials authentication).

A (possibly related) issue in Keycloak 4.7.0 also prevents us from being able to restrict access to the Keycloak admin console, but still allow user management (see [KEYCLOAK-9066](https://issues.jboss.org/browse/KEYCLOAK-9066)).