### PR TITLE
MSPSDS-530: Restrict case legal reasons

### DIFF
--- a/web/app/controllers/businesses_controller.rb
+++ b/web/app/controllers/businesses_controller.rb
@@ -16,7 +16,6 @@ class BusinessesController < ApplicationController
   # GET /businesses/1
   # GET /businesses/1.json
   def show
-    @investigations = @business.investigations
     return unless @business.from_companies_house?
 
     CompaniesHouseClient.instance.update_business_from_companies_house(@business)

--- a/web/app/controllers/investigations_controller.rb
+++ b/web/app/controllers/investigations_controller.rb
@@ -57,6 +57,7 @@ class InvestigationsController < ApplicationController
     @investigation.is_closed = ps[:is_closed] if ps[:is_closed]
     @investigation.status_rationale = ps[:status_rationale] if ps[:status_rationale]
     @investigation.assignee = User.find_by(id: ps[:assignee_id]) if ps[:assignee_id]
+    @investigation.private = ps[:is_private] if ps[:is_private]
     respond_to do |format|
       if @investigation.save
         format.html { redirect_to @investigation, notice: "Case was successfully updated." }
@@ -104,6 +105,6 @@ private
     if params[:investigation][:assignee_id].blank?
       params[:investigation][:assignee_id] = params[:investigation][:assignee_id_radio]
     end
-    params.require(:investigation).permit(:is_closed, :status_rationale, :assignee_id)
+    params.require(:investigation).permit(:is_closed, :status_rationale, :assignee_id, :is_private)
   end
 end

--- a/web/app/controllers/investigations_controller.rb
+++ b/web/app/controllers/investigations_controller.rb
@@ -2,7 +2,7 @@ class InvestigationsController < ApplicationController
   include InvestigationsHelper
 
   before_action :set_search_params, only: %i[index]
-  before_action :set_investigation, only: %i[show update assign status]
+  before_action :set_investigation, only: %i[show update assign status visibility]
 
   # GET /cases
   # GET /cases.json
@@ -50,6 +50,9 @@ class InvestigationsController < ApplicationController
   # GET /cases/1/assign
   def assign; end
 
+  # GET /cases/1/visibility
+  def visibility; end
+
   # PATCH/PUT /cases/1
   # PATCH/PUT /cases/1.json
   def update
@@ -57,7 +60,7 @@ class InvestigationsController < ApplicationController
     @investigation.is_closed = ps[:is_closed] if ps[:is_closed]
     @investigation.status_rationale = ps[:status_rationale] if ps[:status_rationale]
     @investigation.assignee = User.find_by(id: ps[:assignee_id]) if ps[:assignee_id]
-    @investigation.private = ps[:is_private] if ps[:is_private]
+    @investigation.is_private = ps[:is_private] if ps[:is_private]
     respond_to do |format|
       if @investigation.save
         format.html { redirect_to @investigation, notice: "Case was successfully updated." }

--- a/web/app/helpers/investigations_helper.rb
+++ b/web/app/helpers/investigations_helper.rb
@@ -25,8 +25,8 @@ module InvestigationsHelper
 
   def get_must_filters
     must = []
-    must.push(get_status_filter) if get_status_filter.present?
-    must.push(get_visibility_filter)
+    must << get_status_filter if get_status_filter.present?
+    must << get_visibility_filter
     { must: must }
   end
 
@@ -42,6 +42,11 @@ module InvestigationsHelper
   end
 
   def get_visibility_filter
+    # TODO: this is bad when multiple users use service
+    # Need to store some sort of visibility object that will be matched to the one we send here
+    # String of organisations allowed to see it would work. Relation of such organizations would work if we include
+    # them in index
+    # Then we just need to send our organization name in place of can_be_displayed_string.
     { term: { can_be_displayed_string: 'true' } }
   end
 

--- a/web/app/helpers/investigations_helper.rb
+++ b/web/app/helpers/investigations_helper.rb
@@ -42,11 +42,6 @@ module InvestigationsHelper
   end
 
   def get_visibility_filter
-    # TODO: this is bad when multiple users use service
-    # Need to store some sort of visibility object that will be matched to the one we send here
-    # String of organisations allowed to see it would work. Relation of such organizations would work if we include
-    # them in index
-    # Then we just need to send our organization name in place of can_be_displayed_string.
     { term: { who_can_see: current_user.id } }
   end
 

--- a/web/app/helpers/investigations_helper.rb
+++ b/web/app/helpers/investigations_helper.rb
@@ -21,6 +21,7 @@ module InvestigationsHelper
     filters = {}
     filters.merge!(get_status_filter)
     filters.merge!(get_assignee_filter)
+    filters.merge!(get_visibility_filter)
   end
 
   def get_status_filter
@@ -65,6 +66,10 @@ module InvestigationsHelper
     assignee_terms = format_assignee_terms(assignees)
     excluded_assignee_terms = format_assignee_terms(excluded_assignees)
     { should: assignee_terms, must_not: excluded_assignee_terms }
+  end
+
+  def get_visibility_filter
+    { must: { term: { can_be_displayed: 'true' } } }
   end
 
   def format_assignee_terms(assignee_array)

--- a/web/app/helpers/investigations_helper.rb
+++ b/web/app/helpers/investigations_helper.rb
@@ -19,9 +19,15 @@ module InvestigationsHelper
 
   def filter_params
     filters = {}
-    filters.merge!(get_status_filter)
+    filters.merge!(get_must_filters)
     filters.merge!(get_assignee_filter)
-    filters.merge!(get_visibility_filter)
+  end
+
+  def get_must_filters
+    must = []
+    must.push(get_status_filter) if get_status_filter.present?
+    must.push(get_visibility_filter)
+    { must: must }
   end
 
   def get_status_filter
@@ -32,7 +38,11 @@ module InvestigationsHelper
              else
                { is_closed: true }
              end
-    { must: { term: status } }
+    { term: status }
+  end
+
+  def get_visibility_filter
+    { term: { can_be_displayed_string: 'true' } }
   end
 
   def get_assignee_filter
@@ -66,10 +76,6 @@ module InvestigationsHelper
     assignee_terms = format_assignee_terms(assignees)
     excluded_assignee_terms = format_assignee_terms(excluded_assignees)
     { should: assignee_terms, must_not: excluded_assignee_terms }
-  end
-
-  def get_visibility_filter
-    { must: { term: { can_be_displayed_string: 'true' } } }
   end
 
   def format_assignee_terms(assignee_array)

--- a/web/app/helpers/investigations_helper.rb
+++ b/web/app/helpers/investigations_helper.rb
@@ -69,7 +69,7 @@ module InvestigationsHelper
   end
 
   def get_visibility_filter
-    { must: { term: { can_be_displayed: 'true' } } }
+    { must: { term: { can_be_displayed_string: 'true' } } }
   end
 
   def format_assignee_terms(assignee_array)

--- a/web/app/helpers/investigations_helper.rb
+++ b/web/app/helpers/investigations_helper.rb
@@ -42,7 +42,14 @@ module InvestigationsHelper
   end
 
   def get_visibility_filter
-    { term: { who_can_see: current_user.id } }
+    {
+      bool: {
+        should: [
+          { term: { who_can_see: current_user.id } },
+          { term: { is_private: false } }
+        ]
+      }
+    }
   end
 
   def get_assignee_filter

--- a/web/app/helpers/investigations_helper.rb
+++ b/web/app/helpers/investigations_helper.rb
@@ -47,7 +47,7 @@ module InvestigationsHelper
     # String of organisations allowed to see it would work. Relation of such organizations would work if we include
     # them in index
     # Then we just need to send our organization name in place of can_be_displayed_string.
-    { term: { can_be_displayed_string: 'true' } }
+    { term: { who_can_see: current_user.id } }
   end
 
   def get_assignee_filter

--- a/web/app/mailers/notify_mailer.rb
+++ b/web/app/mailers/notify_mailer.rb
@@ -1,11 +1,11 @@
 class NotifyMailer < GovukNotifyRails::Mailer
-  def assigned_investigation(investigation, name, email)
+  def assigned_investigation(investigation_id, name, email)
     set_template('b8260d95-84f8-4f45-928e-7916d27b5a80')
     set_reference('Case assigned')
 
     set_personalisation(
       name: name,
-      investigation_url: investigation_url(investigation)
+      investigation_url: investigation_url(id:investigation_id)
     )
 
     mail(to: email)

--- a/web/app/models/business.rb
+++ b/web/app/models/business.rb
@@ -71,7 +71,7 @@ class Business < ApplicationRecord
   end
 
   def visible_investigations
-    investigations.select{|investigation| investigation.can_be_displayed}
+    investigations.select(&:can_be_displayed)
   end
 
 private

--- a/web/app/models/business.rb
+++ b/web/app/models/business.rb
@@ -70,6 +70,10 @@ class Business < ApplicationRecord
     "Business #{id}"
   end
 
+  def visible_investigations
+    investigations.select{|investigation| investigation.can_be_displayed}
+  end
+
 private
 
   def add_sic_code(c_h_info)

--- a/web/app/models/concerns/searchable.rb
+++ b/web/app/models/concerns/searchable.rb
@@ -67,6 +67,7 @@ module Searchable
     # https://github.com/elastic/elasticsearch-rails/pull/703
     after_update do |document|
       document.__elasticsearch__.update_document_attributes updated_at: document.updated_at
+      document.__elasticsearch__.update_document_attributes who_can_see: document.who_can_see if document.is_a? Investigation
     end
 
     def self.full_search(query)

--- a/web/app/models/investigation.rb
+++ b/web/app/models/investigation.rb
@@ -205,7 +205,7 @@ private
 
   def send_assignee_email
     if saved_changes.key? :assignee_id
-      # NotifyMailer.assigned_investigation(self, assignee.full_name, assignee.email).deliver_later
+      NotifyMailer.assigned_investigation(id, assignee.full_name, assignee.email).deliver_later
     end
   end
 

--- a/web/app/models/investigation.rb
+++ b/web/app/models/investigation.rb
@@ -61,7 +61,7 @@ class Investigation < ApplicationRecord
   def as_indexed_json(*)
     as_json(
       methods: %i[pretty_id who_can_see],
-      only: %i[question_title description hazard_type product_type is_closed assignee_id updated_at created_at],
+      only: %i[question_title description hazard_type product_type is_closed assignee_id updated_at created_at is_private],
       include: {
         documents: {
           only: [],
@@ -105,8 +105,9 @@ class Investigation < ApplicationRecord
   end
 
   def who_can_see
+    return [] unless is_private
     users = User.all.select do |u|
-      !is_private || (u == assignee || u == source&.user)
+      u == assignee || u == source&.user
     end
     users.map {|u| u.id}
   end

--- a/web/app/models/investigation.rb
+++ b/web/app/models/investigation.rb
@@ -59,7 +59,7 @@ class Investigation < ApplicationRecord
 
   def as_indexed_json(*)
     as_json(
-      methods: %i[pretty_id can_be_displayed],
+      methods: %i[pretty_id can_be_displayed_string],
       only: %i[question_title description hazard_type product_type is_closed assignee_id updated_at created_at],
       include: {
         documents: {
@@ -98,9 +98,13 @@ class Investigation < ApplicationRecord
   end
 
   def can_be_displayed
-    return 'true' unless is_private
+    return true unless is_private
 
-    return (current_user == source.user).to_s
+    current_user == source.user
+  end
+
+  def can_be_displayed_string
+    can_be_displayed ? 'true' : 'false'
   end
 
   def pretty_id

--- a/web/app/models/investigation.rb
+++ b/web/app/models/investigation.rb
@@ -25,6 +25,7 @@ class Investigation < ApplicationRecord
     mappings do
       indexes :status, type: :keyword
       indexes :assignee_id, type: :keyword
+      indexes :who_can_see, type: :keyword
     end
   end
 
@@ -59,7 +60,7 @@ class Investigation < ApplicationRecord
 
   def as_indexed_json(*)
     as_json(
-      methods: %i[pretty_id can_be_displayed_string],
+      methods: %i[pretty_id who_can_see],
       only: %i[question_title description hazard_type product_type is_closed assignee_id updated_at created_at],
       include: {
         documents: {
@@ -103,8 +104,8 @@ class Investigation < ApplicationRecord
     current_user == source.user
   end
 
-  def can_be_displayed_string
-    can_be_displayed ? 'true' : 'false'
+  def who_can_see
+    User.all.map {|u| u.id}
   end
 
   def pretty_id

--- a/web/app/models/investigation.rb
+++ b/web/app/models/investigation.rb
@@ -6,8 +6,6 @@ class Investigation < ApplicationRecord
 
   attr_accessor :status_rationale
 
-  attribute :is_private
-
   validates :question_title, presence: true, on: :question_details
   validates :description, presence: true, on: %i[allegation_details question_details]
   validates :hazard_type, presence: true, on: :allegation_details
@@ -93,6 +91,10 @@ class Investigation < ApplicationRecord
 
   def status
     is_closed? ? "Closed" : "Open"
+  end
+
+  def visibility
+    is_private ? "Private - Only my organisation" : "Public - Visible to all"
   end
 
   def pretty_id

--- a/web/app/models/investigation.rb
+++ b/web/app/models/investigation.rb
@@ -105,7 +105,10 @@ class Investigation < ApplicationRecord
   end
 
   def who_can_see
-    User.all.map {|u| u.id}
+    users = User.all.select do |u|
+      !is_private || (u == assignee || u == source&.user)
+    end
+    users.map {|u| u.id}
   end
 
   def pretty_id
@@ -202,7 +205,7 @@ private
 
   def send_assignee_email
     if saved_changes.key? :assignee_id
-      NotifyMailer.assigned_investigation(self, assignee.full_name, assignee.email).deliver_later
+      # NotifyMailer.assigned_investigation(self, assignee.full_name, assignee.email).deliver_later
     end
   end
 

--- a/web/app/models/investigation.rb
+++ b/web/app/models/investigation.rb
@@ -59,7 +59,7 @@ class Investigation < ApplicationRecord
 
   def as_indexed_json(*)
     as_json(
-      methods: :pretty_id,
+      methods: %i[pretty_id can_be_displayed],
       only: %i[question_title description hazard_type product_type is_closed assignee_id updated_at created_at],
       include: {
         documents: {
@@ -95,6 +95,12 @@ class Investigation < ApplicationRecord
 
   def visibility
     is_private ? "Private - Only my organisation" : "Public - Visible to all"
+  end
+
+  def can_be_displayed
+    return 'true' unless is_private
+
+    return (current_user == source.user).to_s
   end
 
   def pretty_id

--- a/web/app/models/investigation.rb
+++ b/web/app/models/investigation.rb
@@ -6,6 +6,8 @@ class Investigation < ApplicationRecord
 
   attr_accessor :status_rationale
 
+  attribute :is_private
+
   validates :question_title, presence: true, on: :question_details
   validates :description, presence: true, on: %i[allegation_details question_details]
   validates :hazard_type, presence: true, on: :allegation_details

--- a/web/app/models/product.rb
+++ b/web/app/models/product.rb
@@ -32,7 +32,7 @@ class Product < ApplicationRecord
   end
 
   def visible_investigations
-    investigations.select{|investigation| investigation.can_be_displayed}
+    investigations.select(&:can_be_displayed)
   end
 end
 

--- a/web/app/models/product.rb
+++ b/web/app/models/product.rb
@@ -30,6 +30,10 @@ class Product < ApplicationRecord
   def pretty_description
     "Product #{id}"
   end
+
+  def visible_investigations
+    investigations.select{|investigation| investigation.can_be_displayed}
+  end
 end
 
 Product.import force: true if Rails.env.development? # for auto sync model with elastic search

--- a/web/app/views/application/_business_heading.html.slim
+++ b/web/app/views/application/_business_heading.html.slim
@@ -11,4 +11,4 @@
           th.govuk-table__header[scope="row"]
             span.govuk-caption-m[class="govuk-!-font-size-16"]
               | Cases
-            = business.investigations.count
+            = business.visible_investigations.count

--- a/web/app/views/application/_product_heading.html.slim
+++ b/web/app/views/application/_product_heading.html.slim
@@ -13,4 +13,4 @@
           th.govuk-table__header[scope="row"]
             span.govuk-caption-m[class="govuk-!-font-size-16"]
               | Cases
-            = product.investigations.count
+            = product.visible_investigations.count

--- a/web/app/views/businesses/_table.html.slim
+++ b/web/app/views/businesses/_table.html.slim
@@ -20,7 +20,7 @@ table.govuk-table.sortable[class="govuk-!-margin-bottom-3"]
           = business.locations.first ? business.locations.first.short : ""
         td.govuk-table__cell.right-aligned
           span[class="govuk-!-font-size-36 govuk-!-font-weight-bold"]
-            = business.investigations.count
+            = business.visible_investigations.count
     - if businesses.empty?
       tr.govuk-table__row
         td.govuk-table__cell[colspan="5"]

--- a/web/app/views/businesses/tabs/_cases.html.slim
+++ b/web/app/views/businesses/tabs/_cases.html.slim
@@ -1,3 +1,3 @@
 .govuk-grid-row class="govuk-!-margin-top-6"
   .govuk-grid-column-full
-    = render "investigations_summary", investigations: @business.investigations
+    = render "investigations_summary", investigations: @business.visible_investigations

--- a/web/app/views/investigations/show.html.slim
+++ b/web/app/views/investigations/show.html.slim
@@ -12,7 +12,8 @@ hr.govuk-section-break.govuk-section-break--m
   Tab.new("activity", "Activity", lambda { render "investigations/tabs/activity" }),
   Tab.new("products", "Products", lambda { render "investigations/tabs/products" }),
   Tab.new("businesses", "Businesses", lambda { render "investigations/tabs/businesses" }),
-  Tab.new("attachments", "Attachments", lambda { render "investigations/tabs/attachments" })\
+  Tab.new("attachments", "Attachments", lambda { render "investigations/tabs/attachments" }),
+  Tab.new("details", "Full details", lambda {render "investigations/tabs/full_details"})\
 ]
 
 .no-print[class="govuk-!-margin-top-3"]

--- a/web/app/views/investigations/status.html.slim
+++ b/web/app/views/investigations/status.html.slim
@@ -3,7 +3,7 @@
   = link_to "Back to case", @investigation, class: "govuk-back-link"
 = render "minimal_investigation_heading", investigation: @investigation, title: "Status information"
 h2.govuk-heading-l
-  | Case status
+  = "#{case_question_text(investigation).titleize} status"
 = form_with(model: @investigation, local: true) do |form|
   .govuk-form-group
     fieldset.govuk-fieldset

--- a/web/app/views/investigations/status.html.slim
+++ b/web/app/views/investigations/status.html.slim
@@ -3,7 +3,7 @@
   = link_to "Back to case", @investigation, class: "govuk-back-link"
 = render "minimal_investigation_heading", investigation: @investigation, title: "Status information"
 h2.govuk-heading-l
-  = "#{case_question_text(investigation).titleize} status"
+  = "#{case_question_text(@investigation).titleize} status"
 = form_with(model: @investigation, local: true) do |form|
   .govuk-form-group
     fieldset.govuk-fieldset

--- a/web/app/views/investigations/tabs/_full_details.html.slim
+++ b/web/app/views/investigations/tabs/_full_details.html.slim
@@ -6,3 +6,5 @@ hr.govuk-section-break.govuk-section-break--l
   .govuk-grid-column-full
     = "Visibility: "
     = @investigation.visibility
+
+    p = @investigation.can_be_displayed

--- a/web/app/views/investigations/tabs/_full_details.html.slim
+++ b/web/app/views/investigations/tabs/_full_details.html.slim
@@ -1,0 +1,9 @@
+= link_to "Add product", new_investigation_product_url(@investigation)
+
+hr.govuk-section-break.govuk-section-break--l
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    = "Visibility: "
+    = @investigation.private
+    = link_to "Edit details", @investigation

--- a/web/app/views/investigations/tabs/_full_details.html.slim
+++ b/web/app/views/investigations/tabs/_full_details.html.slim
@@ -1,9 +1,8 @@
-= link_to "Add product", new_investigation_product_url(@investigation)
+p = link_to "Edit details", visibility_investigation_path(@investigation)
 
 hr.govuk-section-break.govuk-section-break--l
 
 .govuk-grid-row
   .govuk-grid-column-full
     = "Visibility: "
-    = @investigation.private
-    = link_to "Edit details", @investigation
+    = @investigation.visibility

--- a/web/app/views/investigations/tabs/_full_details.html.slim
+++ b/web/app/views/investigations/tabs/_full_details.html.slim
@@ -8,3 +8,4 @@ hr.govuk-section-break.govuk-section-break--l
     = @investigation.visibility
 
     p = @investigation.can_be_displayed
+    p = @investigation.who_can_see

--- a/web/app/views/investigations/visibility.html.slim
+++ b/web/app/views/investigations/visibility.html.slim
@@ -3,13 +3,10 @@
   = link_to "Back to case", @investigation, class: "govuk-back-link"
 = render "minimal_investigation_heading", investigation: @investigation, title: "Visibility information"
 h2.govuk-heading-l
-  = "#{case_question_text(investigation).titleize} visibility"
+  = "#{case_question_text(@investigation).titleize} visibility"
 = form_with(model: @investigation, local: true) do |form|
   .govuk-form-group
     fieldset.govuk-fieldset
-      legend.govuk-fieldset__legend
-      h4.govuk-label
-        | Visibility
       .govuk-radios
         .govuk-radios__item
           = form.radio_button :is_private, false, class: "govuk-radios__input"

--- a/web/app/views/investigations/visibility.html.slim
+++ b/web/app/views/investigations/visibility.html.slim
@@ -1,0 +1,21 @@
+- content_for :page_title, "Update visibility"
+- content_for :after_header do
+  = link_to "Back to case", @investigation, class: "govuk-back-link"
+= render "minimal_investigation_heading", investigation: @investigation, title: "Visibility information"
+h2.govuk-heading-l
+  = "#{case_question_text(investigation).titleize} visibility"
+= form_with(model: @investigation, local: true) do |form|
+  .govuk-form-group
+    fieldset.govuk-fieldset
+      legend.govuk-fieldset__legend
+      h4.govuk-label
+        | Visibility
+      .govuk-radios
+        .govuk-radios__item
+          = form.radio_button :is_private, false, class: "govuk-radios__input"
+          = form.label :is_private, "Public - Visible to all", class: "govuk-label govuk-radios__label"
+        .govuk-radios__item
+          = form.radio_button :is_private, true, class: "govuk-radios__input"
+          = form.label :is_private, "Private - Only my organisation", class: "govuk-label govuk-radios__label"
+  .govuk-form-group
+    = form.submit "Save", class: "govuk-button"

--- a/web/app/views/products/_table.html.slim
+++ b/web/app/views/products/_table.html.slim
@@ -20,7 +20,7 @@ table.govuk-table.sortable[class="govuk-!-margin-bottom-3"]
           = product.country_of_origin_for_display
         td.govuk-table__cell.right-aligned
           span[class="govuk-!-font-size-36 govuk-!-font-weight-bold"]
-            = product.investigations.count
+            = product.visible_investigations.count
     - if products.empty?
       tr.govuk-table__row
         td.govuk-table__cell[colspan="5"]

--- a/web/app/views/products/show.pdf.slim
+++ b/web/app/views/products/show.pdf.slim
@@ -60,10 +60,10 @@ table[style="width:100%; text-align:left"]
       | Source
     td
       = @product.source.show
-- if @product.investigations.any?
+- if @product.visible_investigations.any?
   tr
     th
       | Cases
-    - @product.investigations.each do |investigation|
+    - @product.visible_investigations.each do |investigation|
       td
         = link_to investigation.id, polymorphic_url(investigation)

--- a/web/app/views/products/tabs/_cases.html.slim
+++ b/web/app/views/products/tabs/_cases.html.slim
@@ -1,3 +1,3 @@
 .govuk-grid-row class="govuk-!-margin-top-6"
   .govuk-grid-column-full
-    = render "investigations_summary", investigations: @product.investigations
+    = render "investigations_summary", investigations: @product.visible_investigations

--- a/web/config/routes.rb
+++ b/web/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
     member do
       get :status
       get :assign
+      get :visibility
     end
     resources :activities, controller: "investigations/activities", only: %i[create new] do
       collection do

--- a/web/db/migrate/20181219122234_add_private_to_cases.rb
+++ b/web/db/migrate/20181219122234_add_private_to_cases.rb
@@ -1,0 +1,7 @@
+class AddPrivateToCases < ActiveRecord::Migration[5.2]
+  safety_assured do
+    change_table :investigations, bulk: true do |t|
+      t.boolean :is_private, null: false, default: false
+    end
+  end
+end

--- a/web/db/schema.rb
+++ b/web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_06_175853) do
+ActiveRecord::Schema.define(version: 2018_12_19_122234) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -125,6 +125,7 @@ ActiveRecord::Schema.define(version: 2018_12_06_175853) do
     t.string "hazard_type"
     t.boolean "is_case", default: true, null: false
     t.boolean "is_closed", default: false
+    t.boolean "is_private", default: false, null: false
     t.string "product_type"
     t.string "question_title"
     t.string "question_type"

--- a/web/test/controllers/investigations_controller_test.rb
+++ b/web/test/controllers/investigations_controller_test.rb
@@ -280,4 +280,26 @@ class InvestigationsControllerTest < ActionDispatch::IntegrationTest
     get investigations_path format: :xlsx
     assert_response :success
   end
+
+  test "should not show private investigations" do
+    new_investigation_description = "new_investigation_description"
+    post investigations_url, params: {
+      investigation: {
+        description: new_investigation_description
+      }
+    }
+
+    new_investigation = Investigation.find_by(description: new_investigation_description)
+    put investigations_url + "/#{new_investigation.id}", params: {
+      investigation: {
+        is_private: true
+      }
+    }
+
+    logout
+    sign_in_as_user
+    get investigations_path
+    # TODO: Uncomment this when we get organization-based system
+    # assert_not_includes(response.body, new_investigation.pretty_id)
+  end
 end

--- a/web/test/controllers/investigations_controller_test.rb
+++ b/web/test/controllers/investigations_controller_test.rb
@@ -299,7 +299,6 @@ class InvestigationsControllerTest < ActionDispatch::IntegrationTest
     logout
     sign_in_as_user
     get investigations_path
-    # TODO: Uncomment this when we get organization-based system
-    # assert_not_includes(response.body, new_investigation.pretty_id)
+    assert_not_includes(response.body, new_investigation.pretty_id)
   end
 end

--- a/web/test/controllers/investigations_controller_test.rb
+++ b/web/test/controllers/investigations_controller_test.rb
@@ -281,24 +281,34 @@ class InvestigationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should not show private investigations" do
-    new_investigation_description = "new_investigation_description"
-    post investigations_url, params: {
-      investigation: {
-        description: new_investigation_description
-      }
-    }
-
-    new_investigation = Investigation.find_by(description: new_investigation_description)
-    put investigations_url + "/#{new_investigation.id}", params: {
-      investigation: {
-        is_private: true
-      }
-    }
+  test "should not show private investigations to everyone" do
+    create_new_private_case
 
     logout
     sign_in_as_user
     get investigations_path
-    assert_not_includes(response.body, new_investigation.pretty_id)
+    assert_not_includes(response.body, @new_investigation.pretty_id)
+  end
+
+  test "should show private investigations to creator" do
+    create_new_private_case
+
+    get investigations_path
+    assert_includes(response.body, @new_investigation.pretty_id)
+  end
+
+  def create_new_private_case
+    description = "new_investigation_description"
+    post investigations_url, params: {
+      investigation: {
+        description: description
+      }
+    }
+    @new_investigation = Investigation.find_by(description: description)
+    put investigations_url + "/#{@new_investigation.id}", params: {
+      investigation: {
+        is_private: true
+      }
+    }
   end
 end


### PR DESCRIPTION
Blocked by designs. 
Need to know what to display when someone who is not supposed to see tries to access website.
Need to know what activity for changing visibility looks like.

Currently access criteria is based on users, needs to be updated to organisations(hopefully as part of a separate ticket). 

We use a filter on elasticsearch query to not return sensitive cases unless users are whitelisted. For parts of project that use rails relations to get cases instead, we compute visibility of cases on the fly.