### PR TITLE
Revert "Bump clamby from 1.5.0 to 1.6.0 in /web"

### DIFF
--- a/mspsds-web/Gemfile.lock
+++ b/mspsds-web/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
     cf-app-utils (0.6)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
-    clamby (1.6.0)
+    clamby (1.5.0)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
     companies-house-rest (0.4.3)


### PR DESCRIPTION
Reverts UKGovernmentBEIS/beis-mspsds#402.

This change https://github.com/kobaltz/clamby/commit/b83768ff903cd452e89508c9d2bbf8aa218b1b7c#diff-ac582526c3f41813a4599030130cf41eR54 means that we try to run `clamdscan --version`.

Because CloudFoundry installs clamav in a weird place, running just `clamdscan --version` gives `ERROR: Can't parse clamd configuration file /etc/clamav/clamd.conf`.

We'll actually want to run `clamdscan --config-file clamav/clamd.conf --version` (similar to https://github.com/kobaltz/clamby/blob/master/lib/clamby/command.rb#L24).