### PR TITLE
MSPSDS-821 speed up time to staging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ cache:
 stages:
   - Build
   - name: Test
-    if: type = pull_request # This is designed to cut out unnecessary runs of the test suit. See MSPSDS-821 for details.
+    if: type = pull_request # This is designed to cut out unnecessary runs of the test suite. See MSPSDS-821 for details.
   - name: Deploy to int
     if: branch = master AND type != pull_request
   - name: Deploy to staging

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ cache:
 stages:
   - Build
   - name: Test
-    if: type = pull_request
+    if: type = pull_request # This is designed to cut out unnecessary runs of the test suit. See MSPSDS-821 for details.
   - name: Deploy to int
     if: branch = master AND type != pull_request
   - name: Deploy to staging

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ cache:
 
 stages:
   - Build
-  - Test
+  - name: Test
+    if: type = pull_request
   - name: Deploy to int
     if: branch = master AND type != pull_request
   - name: Deploy to staging

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,16 @@ cache:
   - "~/bundle-cache"
   - "~/npm-cache"
 
+stages:
+  - Build
+  - Test
+  - name: Deploy to int
+    if: branch = master AND type != pull_request
+  - name: Deploy to staging
+    if: branch = staging AND type != pull_request
+  - name: Deploy to production
+    if: branch = prod AND type != pull_request
+
 jobs:
   include:
   - stage: Build
@@ -24,7 +34,7 @@ jobs:
     - mkdir -p ~/npm-cache
     install:
     - BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} ./ci/build-docker-images.sh
- 
+
   - stage: Test
     name: MSPSDS Tests
     script: COMPONENT=mspsds-web ./ci/test-if-changed.sh
@@ -34,56 +44,41 @@ jobs:
     script: COMPONENT=cosmetics-web ./ci/test-if-changed.sh
   - name: Cosmetics Static Analysis
     script: COMPONENT=cosmetics-web ./ci/static-analysis-if-changed.sh
-  
+
   - stage: Deploy to int
     name: Deploy MSPSDS web
-    if: branch = master AND type != pull_request
     script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=mspsds-web ./ci/deploy-if-changed.sh
   - name: Deploy MSPSDS worker
-    if: branch = master AND type != pull_request
     script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=mspsds-worker ./ci/deploy-if-changed.sh
   - name: Deploy keycloak
-    if: branch = master AND type != pull_request
     script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=keycloak ./ci/deploy-if-changed.sh
   - name: Deploy Cosmetics web
-    if: branch = master AND type != pull_request
     script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=cosmetics-web ./ci/deploy-if-changed.sh
   - name: Deploy Cosmetics worker
-    if: branch = master AND type != pull_request
     script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=cosmetics-worker ./ci/deploy-if-changed.sh
-  
+
   - stage: Deploy to staging
     name: Deploy MSPSDS web
-    if: branch = staging AND type != pull_request
     script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=mspsds-web ./ci/deploy-if-changed.sh
   - name: Deploy MSPSDS worker
-    if: branch = staging AND type != pull_request
     script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=mspsds-worker ./ci/deploy-if-changed.sh
   - name: Deploy keycloak
-    if: branch = staging AND type != pull_request
     script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=keycloak ./ci/deploy-if-changed.sh
 #  - name: Deploy Cosmetics web
-#    if: branch = staging AND type != pull_request
 #    script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=cosmetics-web ./ci/deploy-if-changed.sh
 #  - name: Deploy Cosmetics worker
-#    if: branch = master AND type != pull_request
 #    script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=cosmetics-worker ./ci/deploy-if-changed.sh
-  
+
   - stage: Deploy to production
     name: Deploy MSPSDS web
-    if: branch = prod AND type != pull_request
     script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=prod COMPONENT=mspsds-web ./ci/deploy-if-changed.sh
   - name: Deploy MSPSDS worker
-    if: branch = prod AND type != pull_request
     script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=prod COMPONENT=mspsds-worker ./ci/deploy-if-changed.sh
   - name: Deploy keycloak
-    if: branch = prod AND type != pull_request
     script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=prod COMPONENT=keycloak ./ci/deploy-if-changed.sh
 #  - name: Deploy Cosmetics web
-#    if: branch = prod AND type != pull_request
 #    script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=prod COMPONENT=cosmetics-web ./ci/deploy-if-changed.sh
 #  - name: Deploy Cosmetics worker
-#    if: branch = master AND type != pull_request
 #    script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=prod COMPONENT=cosmetics-worker ./ci/deploy-if-changed.sh
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,18 @@ sudo: required
 language: generic
 
 services:
-- docker
+  - docker
 
 branches:
   only:
-  - master
-  - staging
-  - prod
+    - master
+    - staging
+    - prod
 
 cache:
   directories:
-  - "~/bundle-cache"
-  - "~/npm-cache"
+    - "~/bundle-cache"
+    - "~/npm-cache"
 
 stages:
   - Build
@@ -28,54 +28,54 @@ stages:
 
 jobs:
   include:
-  - stage: Build
-    before_install:
-    - mkdir -p ~/bundle-cache
-    - mkdir -p ~/npm-cache
-    install:
-    - BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} ./ci/build-docker-images.sh
+    - stage: Build
+      before_install:
+        - mkdir -p ~/bundle-cache
+        - mkdir -p ~/npm-cache
+      install:
+        - BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} ./ci/build-docker-images.sh
 
-  - stage: Test
-    name: MSPSDS Tests
-    script: COMPONENT=mspsds-web ./ci/test-if-changed.sh
-  - name: MSPSDS Static Analysis
-    script: COMPONENT=mspsds-web ./ci/static-analysis-if-changed.sh
-  - name: Cosmetics Tests
-    script: COMPONENT=cosmetics-web ./ci/test-if-changed.sh
-  - name: Cosmetics Static Analysis
-    script: COMPONENT=cosmetics-web ./ci/static-analysis-if-changed.sh
+    - stage: Test
+      name: MSPSDS Tests
+      script: COMPONENT=mspsds-web ./ci/test-if-changed.sh
+    - name: MSPSDS Static Analysis
+      script: COMPONENT=mspsds-web ./ci/static-analysis-if-changed.sh
+    - name: Cosmetics Tests
+      script: COMPONENT=cosmetics-web ./ci/test-if-changed.sh
+    - name: Cosmetics Static Analysis
+      script: COMPONENT=cosmetics-web ./ci/static-analysis-if-changed.sh
 
-  - stage: Deploy to int
-    name: Deploy MSPSDS web
-    script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=mspsds-web ./ci/deploy-if-changed.sh
-  - name: Deploy MSPSDS worker
-    script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=mspsds-worker ./ci/deploy-if-changed.sh
-  - name: Deploy keycloak
-    script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=keycloak ./ci/deploy-if-changed.sh
-  - name: Deploy Cosmetics web
-    script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=cosmetics-web ./ci/deploy-if-changed.sh
-  - name: Deploy Cosmetics worker
-    script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=cosmetics-worker ./ci/deploy-if-changed.sh
+    - stage: Deploy to int
+      name: Deploy MSPSDS web
+      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=mspsds-web ./ci/deploy-if-changed.sh
+    - name: Deploy MSPSDS worker
+      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=mspsds-worker ./ci/deploy-if-changed.sh
+    - name: Deploy keycloak
+      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=keycloak ./ci/deploy-if-changed.sh
+    - name: Deploy Cosmetics web
+      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=cosmetics-web ./ci/deploy-if-changed.sh
+    - name: Deploy Cosmetics worker
+      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=cosmetics-worker ./ci/deploy-if-changed.sh
 
-  - stage: Deploy to staging
-    name: Deploy MSPSDS web
-    script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=mspsds-web ./ci/deploy-if-changed.sh
-  - name: Deploy MSPSDS worker
-    script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=mspsds-worker ./ci/deploy-if-changed.sh
-  - name: Deploy keycloak
-    script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=keycloak ./ci/deploy-if-changed.sh
-#  - name: Deploy Cosmetics web
-#    script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=cosmetics-web ./ci/deploy-if-changed.sh
-#  - name: Deploy Cosmetics worker
-#    script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=cosmetics-worker ./ci/deploy-if-changed.sh
+    - stage: Deploy to staging
+      name: Deploy MSPSDS web
+      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=mspsds-web ./ci/deploy-if-changed.sh
+    - name: Deploy MSPSDS worker
+      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=mspsds-worker ./ci/deploy-if-changed.sh
+    - name: Deploy keycloak
+      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=keycloak ./ci/deploy-if-changed.sh
+    #  - name: Deploy Cosmetics web
+    #    script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=cosmetics-web ./ci/deploy-if-changed.sh
+    #  - name: Deploy Cosmetics worker
+    #    script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=cosmetics-worker ./ci/deploy-if-changed.sh
 
-  - stage: Deploy to production
-    name: Deploy MSPSDS web
-    script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=prod COMPONENT=mspsds-web ./ci/deploy-if-changed.sh
-  - name: Deploy MSPSDS worker
-    script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=prod COMPONENT=mspsds-worker ./ci/deploy-if-changed.sh
-  - name: Deploy keycloak
-    script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=prod COMPONENT=keycloak ./ci/deploy-if-changed.sh
+    - stage: Deploy to production
+      name: Deploy MSPSDS web
+      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=prod COMPONENT=mspsds-web ./ci/deploy-if-changed.sh
+    - name: Deploy MSPSDS worker
+      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=prod COMPONENT=mspsds-worker ./ci/deploy-if-changed.sh
+    - name: Deploy keycloak
+      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=prod COMPONENT=keycloak ./ci/deploy-if-changed.sh
 #  - name: Deploy Cosmetics web
 #    script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=prod COMPONENT=cosmetics-web ./ci/deploy-if-changed.sh
 #  - name: Deploy Cosmetics worker
@@ -86,8 +86,8 @@ notifications:
 
 env:
   global:
-  - COVERALLS_PARALLEL=true
-  - secure: PP1MBuv5m3nsdgVS0UaX2CZPh1Ar8s6k+OZOaNn0oq4JSbvZXm/aEOX50D2AA9pxhXJBC+4NC54pWse9bRIt0etmmC+coYetjVI91xOgH2QgLbEkkfRKE/RKmtKqLAOyvVAB+HvVO/YNetIRGgTQwTnhvmsGL2uj/YFntTLRm/oHZy2vc7leN0gFSzS6oNK4a2L2+Tvl/Ytqhn2f2GUZnVTGJZoDYJKBRdlXZ/ffOsyaLXE8a1mgnuAx/7IUBkvtFKPcXOOtoe0mCU8O1AWszkfSv8GI5OtM54DLrM1b9bU8erkkCzDDSNBj+qDbvaTeGeDf2TH6fmtXSOBZhGpCkAOmaxzqt8RbpemnxM+ij40bXSPrOVGOspn6aPBli/vOxcCzchhl13aYSsRwf1AV+0uViX5Mve3sJnIvIEPH6bblzkRtGjLEWLyqGLU9Gb9l4Fxhxwx0kPmjkNqyhHjSBwTDd7FyDNKQ2k0DRU8hxUqUcKkHliQepN1Ri0manztiS/pf0JF2HDmovLEKC3Ag1EniR9sD74d1TH2lsm70t+Gk/8DGOh2Lbwy94pjUD/GDp0opdGRB5BynsW8TFCehnw/GlWQe7f/U2/X+jZ2oO7jw0eGlC1E9stGfcct8YnENrvrc1iHVQ9JJ78ZzIhnJ3GfD4A7ZKCmXIqucYlrgWSw= # DOCKER_USERNAME
-  - secure: QF+c/OQR3qP+08J5dffdOFWypUIbYsHEeAZxl46AbR9iSaFxbCCltDAESdectTBN5I/RsVNezRfaZ1rtTCSo+F36qbpexwRkNQ/2B9+pnPr9pWkwvKvqlMAtotz8EkCjzG/DQvgMkaBxO8Q/bMv7/rCjv4Fvpmkb6k/MtyGgCcuhknK4kd2BhCEmJLcRr1Oin/SGgaZTRmlhhdZyzveO5Z5Y/8WyoMW6nXfGHOEv0JDcOQmURg2JN2vEhVKXkHlJ+Ij0ZDlL9ZCwuwCKcxe8BmgHMW1XidJwsHKPB/+q2AD8rHefKTU+CkKd55iNKZzD5p4Y8bqSJ1SbUQYaq6UaueqV1KKW7fXMmG8HLUP+rq28ZwnaMbTqdHlZeJHIkaKKS3ACgLOaCJN8lW13WTrHQBGgxE0PXpaSQCXhW9p7Dt0PEz4emsWarC3w0+Fx3t9yI5Zi6nTpEPIkGRgJQQXO6tW7wEzGlnPtQ0O+3kHb903DuwfKJPjmZ8MmTQsz7eP6qs07sKSMaCQ5eeDmAoKRcySM0iIMdgckGpDtYuZcgoGCuHxsGCOeVOjFsme+gPm7teHFRiH0pg0caNjLnTZer5UQBLGNLGSU4yTEgHjVmgZETEyh0fTAkBqiEfondGhCaoNUIrba5KFmC1tRDWyMsn8hr2H4Xyhmqi+OCqtc0L4= # DOCKER_PASSWORD
-  - secure: j6Cgg+lhYfifEhp8XAF3pZQ2Xkco9Flxbp9TeniNVg26zK8OLGABfLrkU6olfi9sYF3Gq4JN/5oEJ8OYqp5CmNsuUnDhdsbDjsPVkg7h1oECirz8lCCPmM4CMmePclC03paZu8LiGA6yUY1n1VI7NItOeWdgi05mwxXjmW5ccwx4VldKLhcejGn0TtN8mZ13mryZpMXK6ifOs+Zy95yLbXQcXl3Z5o1vHd05XEnX3gMMmxCYcFSnYDq5k3xQmpNbRpPt/WHCm4os1lY+exdq+ZNfPMDXkwZgRBea2mU/BhHoNwwPd5ocQrU8yB1kkRy6z9fiPXMWipFdO9+uLl67Grm6hko9+sMeVr02Rzk8UyWfsW9iPI0/X3PRoYwgG7xQXOUwtcqSKowTMhC30rkf03Y2TBRSZsLc3emWyGvKz5alv2ZfjyAtiAEUwBUsmGr9t1DSHHt2bsQpz9NJvHh8uZU1Mzk3ZSn03m8i37UVAXWE6BOYJmDmkERpn+8bbqI/30gMk1c8sXW1gJyb6YyBeLxHt+hB4GAWvTqTbur5fkJUJKzZxqx0jGVtUmRpywT01n0yThH/6lHpFgaB6lgAPasn734WrLZF5SgTyF2z7DywfI7WYNPxfrWCEuOxXAyh4CwmMNhtULyL0JmG5+EhwqOLUVa8aS94Vtwyz37gAHM= # CF_USERNAME
-  - secure: iZ+2Jcf4O2lvuOzzRMa+JU9feVfzZkKdUuH8pMT1zPnpn43f2CG8OIOC1JL4I4YuJnQZSdUKk3blI0Er163BjVDU5gZ3TyRdfH2UxxvQ7pB1O0G1ricBW/Qqv2JpG0Si8j5xOUI329bN69UU9QXgTltr+HYbXoUeLLqYr4ocpDDQb9/MjxsrbC0+cL60xDGse0mPIMeKTfcRehOaej/zsk+jdLaoFkBlC6DI+bQ6Cc/d+78TOtOZ9A98VJd3FjEAi3Fg2pohjTCTVek/7OlJKALYp9gTdRJY+prSeN9nHWEE35WOtEq86Id29ZoIPJ+alioJjxx9ZyNu+wDjhbj31u/WkLErkaN9I+x0+OuXmMDSRlNaTmePNtjA+4FwwAWkp0ZjD5h0BT1gdYntZGflgjIXwWvlq0cKovTwKwGUMcMLLOVpMcPW63kvSseqqMsPFI+G9d1BYcPBYwXmyLNyBWloUC5N8Up/9RCuGS9fUiqVmn8lT93HVla5YDYyjS3vcXIuR2za2gk8lXwEyMGZDcqafXsA+XN3borAuw3qfb5kHU5/zSijUswh4/2LD1ZICiQ5pohoy9pF3baWSF6psymqHXSrwWrHc00SOBpCqP7k4o06cywQrD1CW/aSohxTJpOFhjFOuJzgl7KDwbu/s/hCMSmB8Sdo1diXiEDJwsQ= # CF_PASSWORD
+    - COVERALLS_PARALLEL=true
+    - secure: PP1MBuv5m3nsdgVS0UaX2CZPh1Ar8s6k+OZOaNn0oq4JSbvZXm/aEOX50D2AA9pxhXJBC+4NC54pWse9bRIt0etmmC+coYetjVI91xOgH2QgLbEkkfRKE/RKmtKqLAOyvVAB+HvVO/YNetIRGgTQwTnhvmsGL2uj/YFntTLRm/oHZy2vc7leN0gFSzS6oNK4a2L2+Tvl/Ytqhn2f2GUZnVTGJZoDYJKBRdlXZ/ffOsyaLXE8a1mgnuAx/7IUBkvtFKPcXOOtoe0mCU8O1AWszkfSv8GI5OtM54DLrM1b9bU8erkkCzDDSNBj+qDbvaTeGeDf2TH6fmtXSOBZhGpCkAOmaxzqt8RbpemnxM+ij40bXSPrOVGOspn6aPBli/vOxcCzchhl13aYSsRwf1AV+0uViX5Mve3sJnIvIEPH6bblzkRtGjLEWLyqGLU9Gb9l4Fxhxwx0kPmjkNqyhHjSBwTDd7FyDNKQ2k0DRU8hxUqUcKkHliQepN1Ri0manztiS/pf0JF2HDmovLEKC3Ag1EniR9sD74d1TH2lsm70t+Gk/8DGOh2Lbwy94pjUD/GDp0opdGRB5BynsW8TFCehnw/GlWQe7f/U2/X+jZ2oO7jw0eGlC1E9stGfcct8YnENrvrc1iHVQ9JJ78ZzIhnJ3GfD4A7ZKCmXIqucYlrgWSw= # DOCKER_USERNAME
+    - secure: QF+c/OQR3qP+08J5dffdOFWypUIbYsHEeAZxl46AbR9iSaFxbCCltDAESdectTBN5I/RsVNezRfaZ1rtTCSo+F36qbpexwRkNQ/2B9+pnPr9pWkwvKvqlMAtotz8EkCjzG/DQvgMkaBxO8Q/bMv7/rCjv4Fvpmkb6k/MtyGgCcuhknK4kd2BhCEmJLcRr1Oin/SGgaZTRmlhhdZyzveO5Z5Y/8WyoMW6nXfGHOEv0JDcOQmURg2JN2vEhVKXkHlJ+Ij0ZDlL9ZCwuwCKcxe8BmgHMW1XidJwsHKPB/+q2AD8rHefKTU+CkKd55iNKZzD5p4Y8bqSJ1SbUQYaq6UaueqV1KKW7fXMmG8HLUP+rq28ZwnaMbTqdHlZeJHIkaKKS3ACgLOaCJN8lW13WTrHQBGgxE0PXpaSQCXhW9p7Dt0PEz4emsWarC3w0+Fx3t9yI5Zi6nTpEPIkGRgJQQXO6tW7wEzGlnPtQ0O+3kHb903DuwfKJPjmZ8MmTQsz7eP6qs07sKSMaCQ5eeDmAoKRcySM0iIMdgckGpDtYuZcgoGCuHxsGCOeVOjFsme+gPm7teHFRiH0pg0caNjLnTZer5UQBLGNLGSU4yTEgHjVmgZETEyh0fTAkBqiEfondGhCaoNUIrba5KFmC1tRDWyMsn8hr2H4Xyhmqi+OCqtc0L4= # DOCKER_PASSWORD
+    - secure: j6Cgg+lhYfifEhp8XAF3pZQ2Xkco9Flxbp9TeniNVg26zK8OLGABfLrkU6olfi9sYF3Gq4JN/5oEJ8OYqp5CmNsuUnDhdsbDjsPVkg7h1oECirz8lCCPmM4CMmePclC03paZu8LiGA6yUY1n1VI7NItOeWdgi05mwxXjmW5ccwx4VldKLhcejGn0TtN8mZ13mryZpMXK6ifOs+Zy95yLbXQcXl3Z5o1vHd05XEnX3gMMmxCYcFSnYDq5k3xQmpNbRpPt/WHCm4os1lY+exdq+ZNfPMDXkwZgRBea2mU/BhHoNwwPd5ocQrU8yB1kkRy6z9fiPXMWipFdO9+uLl67Grm6hko9+sMeVr02Rzk8UyWfsW9iPI0/X3PRoYwgG7xQXOUwtcqSKowTMhC30rkf03Y2TBRSZsLc3emWyGvKz5alv2ZfjyAtiAEUwBUsmGr9t1DSHHt2bsQpz9NJvHh8uZU1Mzk3ZSn03m8i37UVAXWE6BOYJmDmkERpn+8bbqI/30gMk1c8sXW1gJyb6YyBeLxHt+hB4GAWvTqTbur5fkJUJKzZxqx0jGVtUmRpywT01n0yThH/6lHpFgaB6lgAPasn734WrLZF5SgTyF2z7DywfI7WYNPxfrWCEuOxXAyh4CwmMNhtULyL0JmG5+EhwqOLUVa8aS94Vtwyz37gAHM= # CF_USERNAME
+    - secure: iZ+2Jcf4O2lvuOzzRMa+JU9feVfzZkKdUuH8pMT1zPnpn43f2CG8OIOC1JL4I4YuJnQZSdUKk3blI0Er163BjVDU5gZ3TyRdfH2UxxvQ7pB1O0G1ricBW/Qqv2JpG0Si8j5xOUI329bN69UU9QXgTltr+HYbXoUeLLqYr4ocpDDQb9/MjxsrbC0+cL60xDGse0mPIMeKTfcRehOaej/zsk+jdLaoFkBlC6DI+bQ6Cc/d+78TOtOZ9A98VJd3FjEAi3Fg2pohjTCTVek/7OlJKALYp9gTdRJY+prSeN9nHWEE35WOtEq86Id29ZoIPJ+alioJjxx9ZyNu+wDjhbj31u/WkLErkaN9I+x0+OuXmMDSRlNaTmePNtjA+4FwwAWkp0ZjD5h0BT1gdYntZGflgjIXwWvlq0cKovTwKwGUMcMLLOVpMcPW63kvSseqqMsPFI+G9d1BYcPBYwXmyLNyBWloUC5N8Up/9RCuGS9fUiqVmn8lT93HVla5YDYyjS3vcXIuR2za2gk8lXwEyMGZDcqafXsA+XN3borAuw3qfb5kHU5/zSijUswh4/2LD1ZICiQ5pohoy9pF3baWSF6psymqHXSrwWrHc00SOBpCqP7k4o06cywQrD1CW/aSohxTJpOFhjFOuJzgl7KDwbu/s/hCMSmB8Sdo1diXiEDJwsQ= # CF_PASSWORD


### PR DESCRIPTION
@broder when we've discussed this in a couple weeks back, I recall our conclusion was to disable tests on PR builds coming from master.
I'm no longer sure about that logic and have opted for disabling tests on non-pr builds, with the following logic.

1. We want to avoid an untested version of the code to be released. Such a commit on say staging could come from
  A) a PR from master, 
  B) a PR from feature/hotfix branch, 
  C) an admin updating the master branch with staging/prod merge to enable PR from master to staging/prod (when doing staging/prod release).
2. In cases A + B, the PR will have run the same version of the code and tested it. We've got checks that ensure this.
3. In case C, 99% of the time the commit will be empty, since master is practically ahead of the staging/prod branch except for the merge commit form the last branch. The only time when that's not true is when we've deployed a hotfix to staging/prod. In this case
  i) The hotifx code will have been tested with it's own PR, so we only need to worry about the combination of hotfix + changes on master
ii) When resorting to a hotfix, the dev should also be merging it into master as well as staging/prod
iii) Even if that's not followed, the most we break is INT - the code won't be deployed further to staging, as it will get flagged up in the staging PR.

Happy to be proven wrong here if there's a hole in my thinking!