### PR TITLE
MSPSDS-686: Potentially speed up asset compilation on first run

### DIFF
--- a/shared-web/config/initializers/assets.rb
+++ b/shared-web/config/initializers/assets.rb
@@ -3,6 +3,10 @@
 # Version of your assets, change this if you want to expire all your assets.
 Rails.application.config.assets.version = '1.0'
 
+Rails.application.config.assets.configure do |env|
+  env.cache = ActiveSupport::Cache.lookup_store(:memory_store, size: 128.megabytes) unless Rails.env.production?
+end
+
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
 # Add Yarn node_modules folder to the asset load path.


### PR DESCRIPTION
I think the reason that we sometimes get timeouts on our tests and when we first load the app locally is because of the [poor docker volume performance on not-linux](https://docs.docker.com/docker-for-mac/osxfs-caching/) (i.e. mac or windows) which affects our asset compilation (which does lots of IO operations).

https://docs.docker.com/v17.09/engine/admin/volumes/tmpfs/ for the `tmp/` folder seems like it would be the best solution but it's linux only

Putting the asset cache in memory reduces the number of IO operations.

I also tried using the `delegated` flag mentioned in the first link but the in-memory cache performance was better.