### PR TITLE
MSPSDS-948: Add keycloak system out event logger

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -6,11 +6,19 @@ update_configs:
     update_schedule: "daily"
 
   - package_manager: "java:maven"
+    directory: "/keycloak/providers/email"
+    update_schedule: "daily"
+
+  - package_manager: "java:maven"
+    directory: "/keycloak/providers/registration-form"
+    update_schedule: "daily"
+
+  - package_manager: "java:maven"
     directory: "/keycloak/providers/rest-api"
     update_schedule: "daily"
 
   - package_manager: "java:maven"
-    directory: "/keycloak/providers/email"
+    directory: "/keycloak/providers/system-out-event-listener"
     update_schedule: "daily"
 
   - package_manager: "javascript"

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -78,6 +78,18 @@ RUN mvn -q --file ./sms-authenticator/pom.xml package
 RUN cp ./sms-authenticator/target/keycloak-sms-authenticator-sns-*.jar ./providers/
 
 
+# Build and copy the System Out event listener provider
+FROM maven as system-out-event-listener-build
+
+WORKDIR /tmp/keycloak
+
+COPY ./providers/system-out-event-listener ./system-out-event-listener
+RUN mkdir -p ./providers
+
+RUN mvn -q --file ./system-out-event-listener/pom.xml package
+RUN cp ./system-out-event-listener/target/system-out-event-listener-*.jar ./providers/
+
+
 # Build and copy the GOV.UK theme
 FROM node as theme-build
 
@@ -98,10 +110,11 @@ WORKDIR /tmp/keycloak/package
 COPY --from=keycloak-build /tmp/keycloak/package .
 
 # Copy the custom providers from the relevant docker images
-COPY --from=rest-api-build /tmp/keycloak/providers ./providers/
 COPY --from=notify-email-build /tmp/keycloak/providers ./providers/
 COPY --from=registration-form-build /tmp/keycloak/providers ./providers/
+COPY --from=rest-api-build /tmp/keycloak/providers ./providers/
 COPY --from=sms-authenticator-build /tmp/keycloak/providers ./providers/
+COPY --from=system-out-event-listener-build /tmp/keycloak/providers ./providers/
 
 # Copy the themes from the theme-build docker image
 COPY --from=theme-build /tmp/govuk-theme/govuk ./themes/govuk

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -117,6 +117,12 @@ Follow the steps in [the SMS autheticator README's Configuration section](
 ./providers/sms-authenticator/README.md#Configuration) to enable SMS two factor authentication. Set the 2FA 
 code length to 6.
 
+### Setup event logging
+Setup the system out event listener:
+* Select Events > Config
+* Add "system-out" to the "Event Listeners" section
+
+
 ### Troubleshooting
 ##### Problem: the keycloak database doesn't exist when running `$ docker-compose up`
 Error message:

--- a/keycloak/providers/system-out-event-listener/pom.xml
+++ b/keycloak/providers/system-out-event-listener/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <name>System Out Event Listener</name>
+    <description>Outputs keycloak events and admin events to System.out</description>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>uk.gov.beis</groupId>
+    <artifactId>system-out-event-listener</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
+        <keycloak.version>4.8.3.Final</keycloak.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-core</artifactId>
+            <version>${keycloak.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi</artifactId>
+            <version>${keycloak.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.keycloak</groupId>
+            <artifactId>keycloak-server-spi-private</artifactId>
+            <version>${keycloak.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>system-out-event-listener</finalName>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/keycloak/providers/system-out-event-listener/src/main/java/uk/gov/beis/mspsds/keycloak/providers/events/SystemOutEventListenerProvider.java
+++ b/keycloak/providers/system-out-event-listener/src/main/java/uk/gov/beis/mspsds/keycloak/providers/events/SystemOutEventListenerProvider.java
@@ -1,0 +1,80 @@
+package uk.gov.beis.mspsds.keycloak.providers.events;
+
+import org.keycloak.events.admin.AdminEvent;
+import org.keycloak.events.Event;
+import org.keycloak.events.EventListenerProvider;
+
+import java.util.Map;
+
+public class SystemOutEventListenerProvider implements EventListenerProvider {
+
+    SystemOutEventListenerProvider() {
+    }
+
+    @Override
+    public void onEvent(Event event) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("type=");
+        sb.append(event.getType());
+        sb.append(", realmId=");
+        sb.append(event.getRealmId());
+        sb.append(", clientId=");
+        sb.append(event.getClientId());
+        sb.append(", userId=");
+        sb.append(event.getUserId());
+        sb.append(", ipAddress=");
+        sb.append(event.getIpAddress());
+
+        if (event.getError() != null) {
+            sb.append(", error=");
+            sb.append(event.getError());
+        }
+
+        if (event.getDetails() != null) {
+            for (Map.Entry<String, String> e : event.getDetails().entrySet()) {
+                sb.append(", ");
+                sb.append(e.getKey());
+                if (e.getValue() == null || e.getValue().indexOf(' ') == -1) {
+                    sb.append("=");
+                    sb.append(e.getValue());
+                } else {
+                    sb.append("='");
+                    sb.append(e.getValue());
+                    sb.append("'");
+                }
+            }
+        }
+
+        System.out.println("EVENT: " + sb.toString());
+    }
+
+    @Override
+    public void onEvent(AdminEvent adminEvent, boolean includeRepresentation) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("operationType=");
+        sb.append(adminEvent.getOperationType());
+        sb.append(", realmId=");
+        sb.append(adminEvent.getAuthDetails().getRealmId());
+        sb.append(", clientId=");
+        sb.append(adminEvent.getAuthDetails().getClientId());
+        sb.append(", userId=");
+        sb.append(adminEvent.getAuthDetails().getUserId());
+        sb.append(", ipAddress=");
+        sb.append(adminEvent.getAuthDetails().getIpAddress());
+        sb.append(", resourcePath=");
+        sb.append(adminEvent.getResourcePath());
+
+        if (adminEvent.getError() != null) {
+            sb.append(", error=");
+            sb.append(adminEvent.getError());
+        }
+
+        System.out.println("EVENT: " + sb.toString());
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/keycloak/providers/system-out-event-listener/src/main/java/uk/gov/beis/mspsds/keycloak/providers/events/SystemOutEventListenerProviderFactory.java
+++ b/keycloak/providers/system-out-event-listener/src/main/java/uk/gov/beis/mspsds/keycloak/providers/events/SystemOutEventListenerProviderFactory.java
@@ -1,0 +1,32 @@
+package uk.gov.beis.mspsds.keycloak.providers.events;
+
+import org.keycloak.Config;
+import org.keycloak.events.EventListenerProvider;
+import org.keycloak.events.EventListenerProviderFactory;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+public class SystemOutEventListenerProviderFactory implements EventListenerProviderFactory {
+
+    @Override
+    public EventListenerProvider create(KeycloakSession session) {
+        return new SystemOutEventListenerProvider();
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public String getId() {
+        return "system-out";
+    }
+}

--- a/keycloak/providers/system-out-event-listener/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
+++ b/keycloak/providers/system-out-event-listener/src/main/resources/META-INF/services/org.keycloak.events.EventListenerProviderFactory
@@ -1,0 +1,1 @@
+uk.gov.beis.mspsds.keycloak.providers.events.SystemOutEventListenerProviderFactory


### PR DESCRIPTION
The logs will then get sent to logit using the `logit-ssl-drain` service.