### PR TITLE
MSPSDS-547: fix migration

### DIFF
--- a/mspsds-web/db/migrate/20190129155220_add_team_assignee_to_investigation.rb
+++ b/mspsds-web/db/migrate/20190129155220_add_team_assignee_to_investigation.rb
@@ -3,23 +3,18 @@ class AddTeamAssigneeToInvestigation < ActiveRecord::Migration[5.2]
     safety_assured do
       reversible do |dir|
         change_table :investigations do |t|
-          t.uuid :assignable_id
           t.string :assignable_type
+          t.rename :assignee_id, :assignable_id
 
           dir.up do
-            Investigation.all.each do |investigation|
-              investigation.update! assignable_type: investigation.assignee_id.present? ? "User" : ""
-              investigation.update! assignable_id: investigation.assignee_id
-            end
-            t.remove :assignee_id
+            Investigation.where.not(assignable_id: nil).update_all(assignable_type: "User")
+            remove_index :investigations, :assignable_id
             add_index :investigations, %i[assignable_type assignable_id]
           end
 
           dir.down do
-            t.uuid :assignee_id
-            Investigation.all.each do |investigation|
-              investigation.update! assignee_id: investigation.assignable_id
-            end
+            Investigation.where(assignable_type: "Team").update_all(assignee_id: nil)
+            remove_index :investigations, %i[assignable_type assignee_id]
             add_index :investigations, :assignee_id
           end
         end


### PR DESCRIPTION
Turns out using `investigation.update!` will trigger callbacks on investigation, and in this particular case one hook checks for a change in assignee, and tries to create audit activity for it :( 

However, `Investigation.update_all` will not trigger callbacks. I pushed this fix to int and it seems to work as expected. 