### PR TITLE
MSPSDS-525: Notify team when assigned

### DIFF
--- a/mspsds-web/app/mailers/notify_mailer.rb
+++ b/mspsds-web/app/mailers/notify_mailer.rb
@@ -10,4 +10,17 @@ class NotifyMailer < GovukNotifyRails::Mailer
 
     mail(to: email)
   end
+
+  def assigned_investigation_to_team(investigation_id, user_name, email, team_name)
+    set_template('32343175-0057-48d8-b954-f05d175d2c2a')
+    set_reference('Case assigned')
+
+    set_personalisation(
+      name: user_name,
+      team_name: team_name,
+      investigation_url: investigation_url(id: investigation_id)
+    )
+
+    mail(to: email)
+  end
 end

--- a/mspsds-web/app/models/investigation.rb
+++ b/mspsds-web/app/models/investigation.rb
@@ -235,6 +235,10 @@ private
   def send_assignee_email
     if saved_changes.key?(:assignable_id) && assignee.is_a?(User)
       NotifyMailer.assigned_investigation(id, assignee.full_name, assignee.email).deliver_later
+    elsif saved_changes.key?(:assignable_id) && assignee.is_a?(Team)
+      assignee.users.each do |member|
+        NotifyMailer.assigned_investigation_to_team(id, member.full_name, member.email, assignee.name).deliver_later
+      end
     end
   end
 end


### PR DESCRIPTION
This solution sends a copy of confirmation to each team member separately. Ideally we would send all these emails in bulk, which seems to be in the feature list on [https://www.notifications.service.gov.uk/features](url). The problem is that there is no documentation for it, and more obvious ways of making it work failed. 

I asked them about it and hopefully they respond soon. 