### PR TITLE
MSPSDS-907: Fix maintenance routing

### DIFF
--- a/cosmetics-web/manifest.yml
+++ b/cosmetics-web/manifest.yml
@@ -7,6 +7,7 @@ applications:
     - ruby_buildpack
   path: .
   command: bin/rake cf:on_first_instance db:migrate && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
+  no-route: true
   services:
     - cosmetics-database
     - cosmetics-redis

--- a/mspsds-web/manifest.yml
+++ b/mspsds-web/manifest.yml
@@ -7,6 +7,7 @@ applications:
     - ruby_buildpack
   path: .
   command: MIGRATION_STATEMENT_TIMEOUT=60000 bin/rake cf:on_first_instance db:migrate && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
+  no-route: true
   services:
     - mspsds-database
     - mspsds-elasticsearch


### PR DESCRIPTION
As we're now sometimes doing `cf push` without `--hostname`, Cloud Foundry assigns a hostname by default (e.g. `mspsds-web.london.cloudapps.digital`) which then breaks the auth flow with Keycloak.

This change should stop that from happening.