### PR TITLE
COSBETA-18 Add unique UK cosmetics product reference number to submitted notifications

### DIFF
--- a/cosmetics-web/app/controllers/notification_build_controller.rb
+++ b/cosmetics-web/app/controllers/notification_build_controller.rb
@@ -43,7 +43,7 @@ class NotificationBuildController < ApplicationController
   end
 
   def new
-    redirect_to wizard_path(steps.first, notification_id: @notification.id)
+    redirect_to wizard_path(steps.first, notification_id: @notification.reference_number)
   end
 
   def finish_wizard_path
@@ -63,7 +63,7 @@ private
   end
 
   def set_notification
-    @notification = Notification.find(params[:notification_id])
+    @notification = Notification.where(reference_number: params[:notification_id]).first
   end
 
   def set_countries

--- a/cosmetics-web/app/controllers/notification_build_controller.rb
+++ b/cosmetics-web/app/controllers/notification_build_controller.rb
@@ -63,7 +63,7 @@ private
   end
 
   def set_notification
-    @notification = Notification.where(reference_number: params[:notification_id]).first
+    @notification = Notification.find_by reference_number: params[:notification_id]
   end
 
   def set_countries

--- a/cosmetics-web/app/controllers/notifications_controller.rb
+++ b/cosmetics-web/app/controllers/notifications_controller.rb
@@ -26,7 +26,7 @@ class NotificationsController < ApplicationController
 private
 
   def set_notification
-    @notification = Notification.where(reference_number: params[:id]).first
+    @notification = Notification.find_by reference_number: params[:id]
   end
 
   def add_image_upload_errors

--- a/cosmetics-web/app/controllers/notifications_controller.rb
+++ b/cosmetics-web/app/controllers/notifications_controller.rb
@@ -26,7 +26,7 @@ class NotificationsController < ApplicationController
 private
 
   def set_notification
-    @notification = Notification.find(params[:id])
+    @notification = Notification.where(reference_number: params[:id]).first
   end
 
   def add_image_upload_errors

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -8,6 +8,15 @@ class Notification < ApplicationRecord
 
   accepts_nested_attributes_for :image_uploads
 
+  before_create do
+    new_reference_number = nil
+    loop do
+      new_reference_number = SecureRandom.rand(100000000)
+      break unless Notification.where(reference_number: new_reference_number).exists?
+    end
+    self.reference_number = new_reference_number
+  end
+
   before_save :add_product_name, if: :will_save_change_to_product_name?
   before_save :add_import_country, if: :will_save_change_to_import_country?
 

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -77,6 +77,10 @@ class Notification < ApplicationRecord
     }
   end
 
+  def to_param
+    reference_number.to_s
+  end
+
 private
 
   def all_required_attributes_must_be_set

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -59,6 +59,10 @@ class Notification < ApplicationRecord
     country_from_code(import_country) || import_country
   end
 
+  def reference_number_for_display
+    "UKCP-%08d" % reference_number
+  end
+
   def images_are_present_and_safe?
     !image_uploads.empty? && image_uploads.all?(&:marked_as_safe?)
   end

--- a/cosmetics-web/app/views/notifications/confirmation.html.slim
+++ b/cosmetics-web/app/views/notifications/confirmation.html.slim
@@ -6,7 +6,7 @@
             .govuk-panel__body
                 | Your cosmetic notification reference number
                 br
-                strong -
+                strong = @notification.reference_number_for_display
         p We have sent confirmation of this to you
         h3.govuk-heading-m What happens next
         p

--- a/cosmetics-web/app/views/notifications/edit.html.slim
+++ b/cosmetics-web/app/views/notifications/edit.html.slim
@@ -42,6 +42,11 @@
                         = @notification.product_name
                 tr.govuk-table__row
                     th.govuk-table__header
+                        | Reference number
+                    td.govuk-table__cell
+                        = @notification.reference_number_for_display
+                tr.govuk-table__row
+                    th.govuk-table__header
                         | Imported
                     td.govuk-table__cell
                         = @notification.import_country.present? ? "Yes" : "No"

--- a/cosmetics-web/config/routes.rb
+++ b/cosmetics-web/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
 
   resources :responsible_persons, only: %i[show] do
     resources :notification_files, controller: "responsible_persons/notification_files", only: %i[new create]
-    resources :notifications, controller: "responsible_persons/notifications", only: %i[index]
+    resources :notifications, param: :reference_number, controller: "responsible_persons/notifications", only: %i[index]
     resources :team_members, controller: "responsible_persons/team_members", only: %i[index]
 
     collection do

--- a/cosmetics-web/db/migrate/20190211144539_add_reference_number_to_notifications.rb
+++ b/cosmetics-web/db/migrate/20190211144539_add_reference_number_to_notifications.rb
@@ -1,0 +1,8 @@
+class AddReferenceNumberToNotifications < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_column :notifications, :reference_number, :integer
+    add_index :notifications, :reference_number, algorithm: :concurrently, unique: true
+  end
+end

--- a/cosmetics-web/db/schema.rb
+++ b/cosmetics-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_05_094834) do
+ActiveRecord::Schema.define(version: 2019_02_11_144539) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,8 @@ ActiveRecord::Schema.define(version: 2019_02_05_094834) do
     t.datetime "updated_at", null: false
     t.string "import_country"
     t.bigint "responsible_person_id"
+    t.integer "reference_number"
+    t.index ["reference_number"], name: "index_notifications_on_reference_number", unique: true
     t.index ["responsible_person_id"], name: "index_notifications_on_responsible_person_id"
   end
 

--- a/cosmetics-web/spec/controllers/notification_build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/notification_build_controller_spec.rb
@@ -15,106 +15,106 @@ RSpec.describe NotificationBuildController, type: :controller do
 
   describe "GET #new" do
     it "redirects to the first step of the manual web form" do
-      get(:new, params: { notification_id: notification.id })
+      get(:new, params: { notification_id: notification.reference_number })
       expect(response).to redirect_to(
-        notification_build_path(notification.id, "add_product_name")
+        notification_build_path(notification.reference_number, "add_product_name")
 )
     end
   end
 
   describe "GET #show" do
     it "assigns the correct notification" do
-      get(:show, params: { notification_id: notification.id, id: 'add_product_name' })
+      get(:show, params: { notification_id: notification.reference_number, id: 'add_product_name' })
       expect(assigns(:notification)).to eq(notification)
     end
 
     it "renders the step template" do
-      get(:show, params: { notification_id: notification.id, id: 'add_product_name' })
+      get(:show, params: { notification_id: notification.reference_number, id: 'add_product_name' })
       expect(response).to render_template(:add_product_name)
     end
 
     it "redirects to the check your answers page on finish" do
-      get(:show, params: { notification_id: notification.id, id: 'wicked_finish' })
+      get(:show, params: { notification_id: notification.reference_number, id: 'wicked_finish' })
       expect(response).to redirect_to(edit_notification_path(notification))
     end
   end
 
   describe "POST #update" do
     it "assigns the correct notification" do
-      post(:update, params: { notification_id: notification.id, id: 'add_product_name',
+      post(:update, params: { notification_id: notification.reference_number, id: 'add_product_name',
                   notification: { product_name: 'Super Shampoo' } })
       expect(assigns(:notification)).to eq(notification)
     end
 
     it "updates notification parameters if present" do
-      post(:update, params: { notification_id: notification.id, id: 'add_product_name',
+      post(:update, params: { notification_id: notification.reference_number, id: 'add_product_name',
                     notification: { product_name: 'Super Shampoo' } })
       expect(notification.reload.product_name).to eq('Super Shampoo')
     end
 
     it "creates a component if single_or_multi_component set to single" do
-      post(:update, params: { notification_id: notification.id, id: 'single_or_multi_component',
+      post(:update, params: { notification_id: notification.reference_number, id: 'single_or_multi_component',
                     single_or_multi_component: "single" })
       expect(notification.components).to have(1).item
     end
 
     # TODO COSBETA-10 Update this test
     it "throws an exception if single_or_multi_component set to multiple" do
-      post(:update, params: { notification_id: notification.id, id: 'single_or_multi_component',
+      post(:update, params: { notification_id: notification.reference_number, id: 'single_or_multi_component',
                   single_or_multi_component: "multiple" })
       expect(notification.components).to have(1).item
     end
 
     it "adds errors if single_or_multi_component is empty" do
-      post(:update, params: { notification_id: notification.id, id: 'single_or_multi_component',
+      post(:update, params: { notification_id: notification.reference_number, id: 'single_or_multi_component',
                               single_or_multi_component: nil })
       expect(assigns(:notification).errors[:components]).to include('Must not be nil')
     end
 
     it "redirects to add_import_country step if is_imported set to true" do
-      post(:update, params: { notification_id: notification.id, id: 'is_imported',
+      post(:update, params: { notification_id: notification.reference_number, id: 'is_imported',
                               is_imported: "true" })
       expect(response).to redirect_to(notification_build_path(notification, :add_import_country))
     end
 
     it "skips add_import_country step if is_imported set to false" do
-      post(:update, params: { notification_id: notification.id, id: 'is_imported',
+      post(:update, params: { notification_id: notification.reference_number, id: 'is_imported',
                               is_imported: "false" })
       expect(response).to redirect_to(notification_build_path(notification, :single_or_multi_component))
     end
 
     it "adds an error if user doesn't pick a radio option for is_imported" do
-      post(:update, params: { notification_id: notification.id, id: 'is_imported',
+      post(:update, params: { notification_id: notification.reference_number, id: 'is_imported',
                               is_imported: nil })
       expect(assigns(:notification).errors[:import_country]).to include('Must not be nil')
     end
 
     it "adds an error if user submits import_country with a blank value" do
-      post(:update, params: { notification_id: notification.id, id: 'add_import_country',
+      post(:update, params: { notification_id: notification.reference_number, id: 'add_import_country',
                     notification: { import_country: '' } })
       expect(assigns(:notification).errors[:import_country]).to include('Must not be blank')
     end
 
     it "continues to next step if user submits import_country with a valid value" do
-      post(:update, params: { notification_id: notification.id, id: 'add_import_country',
+      post(:update, params: { notification_id: notification.reference_number, id: 'add_import_country',
                     notification: { import_country: 'France' } })
       expect(response).to redirect_to(notification_build_path(notification, :single_or_multi_component))
     end
 
     it "adds image files to a notification in the add_product_image step" do
-      post(:update, params: { notification_id: notification.id, id: 'add_product_image',
+      post(:update, params: { notification_id: notification.reference_number, id: 'add_product_image',
                     image_upload: [file] })
       expect(assigns[:notification].image_uploads.first.file.filename).to eq('testImage.png')
     end
 
     it "adds errors if user does not upload images in the add_product_image step" do
-      post(:update, params: { notification_id: notification.id, id: 'add_product_image',
+      post(:update, params: { notification_id: notification.reference_number, id: 'add_product_image',
         image_upload: [] })
       expect(assigns[:notification].errors[:image_uploads]).to include('You must upload at least one product image')
     end
 
     it "adds errors if the user uploads an incorrect file type as a label image" do
-      post(:update, params: { notification_id: notification.id, id: 'add_product_image',
+      post(:update, params: { notification_id: notification.reference_number, id: 'add_product_image',
         image_upload: [text_file] })
       expect(assigns[:notification].image_uploads.first.errors[:file])
         .to include("must be one of image/jpeg, application/pdf, image/png, image/svg+xml")

--- a/cosmetics-web/spec/controllers/notifications_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/notifications_controller_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe NotificationsController, type: :controller do
   describe "GET /confirmation" do
     it "assigns the correct notification" do
       notification = create(:notification)
-      get(:confirmation, params: { id: notification.id })
+      get(:confirmation, params: { id: notification.reference_number })
       expect(assigns(:notification)).to eq(notification)
     end
 
     it "marks the notification as complete" do
       attach_image_to_draft_with_metadata(safe: true)
-      get(:confirmation, params: { id: draft_notification.id })
+      get(:confirmation, params: { id: draft_notification.reference_number })
       expect(draft_notification.reload.state).to eq('notification_complete')
     end
   end
@@ -29,20 +29,20 @@ RSpec.describe NotificationsController, type: :controller do
   describe "GET /edit" do
     it "assigns the correct notification" do
       notification = create(:notification)
-      get(:edit, params: { id: notification.id })
+      get(:edit, params: { id: notification.reference_number })
       expect(assigns(:notification)).to eq(notification)
     end
 
     it "adds error if failed attempt to submit when images are pending anti virus check" do
       attach_image_to_draft_with_metadata({})
-      get(:edit, params: { id: draft_notification.id, submit_failed: true })
+      get(:edit, params: { id: draft_notification.reference_number, submit_failed: true })
       expect(assigns(:notification).errors[:image_uploads]).to include("waiting for files to pass anti virus check. Refresh to update")
     end
 
     it "adds error if failed attempt to submit when images have failed anti virus check" do
       draft_notification.image_uploads.build
       draft_notification.save
-      get(:edit, params: { id: draft_notification.id, submit_failed: true })
+      get(:edit, params: { id: draft_notification.reference_number, submit_failed: true })
       expect(assigns(:notification).errors[:image_uploads]).to include("failed anti virus check")
     end
   end
@@ -55,7 +55,7 @@ RSpec.describe NotificationsController, type: :controller do
 
     it "redirects to the notification build controller" do
       get :new
-      expect(response).to redirect_to(new_notification_build_path(assigns(:notification).id))
+      expect(response).to redirect_to(new_notification_build_path(assigns(:notification).reference_number))
     end
   end
 

--- a/cosmetics-web/spec/system/manual_notification_entry_spec.rb
+++ b/cosmetics-web/spec/system/manual_notification_entry_spec.rb
@@ -159,7 +159,7 @@ private
       reference_number = match.captures[0].to_i
     end
 
-    Notification.where(reference_number: reference_number).first
+    Notification.find_by reference_number: reference_number
   end
 
   # The worker doesn't mark system test images as safe, so we have to do it

--- a/cosmetics-web/spec/system/manual_notification_entry_spec.rb
+++ b/cosmetics-web/spec/system/manual_notification_entry_spec.rb
@@ -156,10 +156,10 @@ private
 
   def get_notification_from_url
     if (match = current_url.match(%r!/notifications/(\d+)/!))
-      notification_id = match.captures[0].to_i
+      reference_number = match.captures[0].to_i
     end
 
-    Notification.find(notification_id)
+    Notification.where(reference_number: reference_number).first
   end
 
   # The worker doesn't mark system test images as safe, so we have to do it


### PR DESCRIPTION
- add `reference_number` column to notifications
- randomly generate reference number on creation of a notification
- display the reference number with a `UKCP-` prefix on check your answers and confirmation pages
- use the reference number in the URLs for the notification