### PR TITLE
MSPSDS-877: Use new way to compute pretty ids

### DIFF
--- a/mspsds-web/app/controllers/concerns/corrective_actions_concern.rb
+++ b/mspsds-web/app/controllers/concerns/corrective_actions_concern.rb
@@ -2,7 +2,7 @@ module CorrectiveActionsConcern
   extend ActiveSupport::Concern
 
   def set_investigation
-    @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id])
+    @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
     authorize @investigation, :show?
   end
 

--- a/mspsds-web/app/controllers/investigations/activities_controller.rb
+++ b/mspsds-web/app/controllers/investigations/activities_controller.rb
@@ -62,7 +62,7 @@ private
   end
 
   def set_investigation
-    @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id])
+    @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
     authorize @investigation, :show?
   end
 

--- a/mspsds-web/app/controllers/investigations/businesses_controller.rb
+++ b/mspsds-web/app/controllers/investigations/businesses_controller.rb
@@ -55,7 +55,7 @@ private
   end
 
   def set_investigation
-    @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id])
+    @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
     authorize @investigation, :show?
   end
 end

--- a/mspsds-web/app/controllers/investigations/correspondence_controller.rb
+++ b/mspsds-web/app/controllers/investigations/correspondence_controller.rb
@@ -49,7 +49,7 @@ private
   end
 
   def set_investigation
-    @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id])
+    @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
     authorize @investigation, :show?
   end
 

--- a/mspsds-web/app/controllers/investigations/products_controller.rb
+++ b/mspsds-web/app/controllers/investigations/products_controller.rb
@@ -56,7 +56,7 @@ private
   end
 
   def set_investigation
-    @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id])
+    @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
     authorize @investigation, :show?
   end
 end

--- a/mspsds-web/app/controllers/investigations_controller.rb
+++ b/mspsds-web/app/controllers/investigations_controller.rb
@@ -118,13 +118,13 @@ private
     @investigation = Investigation.eager_load(:source,
                                               products: { documents_attachments: :blob },
                                               investigation_businesses: { business: :locations },
-                                              documents_attachments: :blob).find_by(pretty_id: params[:pretty_id])
+                                              documents_attachments: :blob).find_by!(pretty_id: params[:pretty_id])
     authorize @investigation, :show?
     preload_activities
   end
 
   def set_investigation
-    @investigation = Investigation.find_by(pretty_id: params[:pretty_id])
+    @investigation = Investigation.find_by!(pretty_id: params[:pretty_id])
     authorize @investigation
   end
 

--- a/mspsds-web/app/helpers/documents_helper.rb
+++ b/mspsds-web/app/helpers/documents_helper.rb
@@ -3,7 +3,7 @@ module DocumentsHelper
   include Pundit
 
   def set_parent
-    @parent = Investigation.find_by(pretty_id: params[:investigation_pretty_id]) if params[:investigation_pretty_id]
+    @parent = Investigation.find_by!(pretty_id: params[:investigation_pretty_id]) if params[:investigation_pretty_id]
     @parent = Product.find(params[:product_id]) if params[:product_id]
     @parent = Business.find(params[:business_id]) if params[:business_id]
     authorize @parent, :show? if @parent.is_a? Investigation

--- a/mspsds-web/app/helpers/tests_helper.rb
+++ b/mspsds-web/app/helpers/tests_helper.rb
@@ -1,6 +1,6 @@
 module TestsHelper
   def set_investigation
-    @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id])
+    @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
     authorize @investigation, :show?
   end
 

--- a/mspsds-web/app/helpers/url_helper.rb
+++ b/mspsds-web/app/helpers/url_helper.rb
@@ -28,7 +28,7 @@ module UrlHelper
     case_id = request.referer&.match(/cases\/(\d+-\d+)/)&.captures&.first
     return nil if case_id.blank?
 
-    investigation = Investigation.find_by(pretty_id: case_id)
+    investigation = Investigation.find_by!(pretty_id: case_id)
     {
       is_simple_link: true,
       link_text: "Back to #{investigation.pretty_description}",

--- a/mspsds-web/app/models/investigation.rb
+++ b/mspsds-web/app/models/investigation.rb
@@ -196,7 +196,7 @@ class Investigation < ApplicationRecord
     pretty_id
   end
 
-  def add_pretty_id(id: Investigation.this_month.where.not(pretty_id: nil).count)
+  def add_pretty_id(id: Investigation.this_month.where("created_at < ?", created_at).count)
     pretty_id = "#{created_at.strftime('%y%m')}-%04d" % id
     self.pretty_id = pretty_id
   end

--- a/mspsds-web/db/migrate/20190215121322_fix_incorrect_pretty_ids.rb
+++ b/mspsds-web/db/migrate/20190215121322_fix_incorrect_pretty_ids.rb
@@ -1,0 +1,7 @@
+class FixIncorrectPrettyIds < ActiveRecord::Migration[5.2]
+  def change
+    Investigation.all.each do |investigation|
+      investigation.add_pretty_id
+    end
+  end
+end

--- a/mspsds-web/db/migrate/20190215121322_fix_incorrect_pretty_ids.rb
+++ b/mspsds-web/db/migrate/20190215121322_fix_incorrect_pretty_ids.rb
@@ -1,5 +1,5 @@
 class FixIncorrectPrettyIds < ActiveRecord::Migration[5.2]
   def change
-    Investigation.all.each(&:add_pretty_id)
+    Investigation.in_batches.each(&:add_pretty_id)
   end
 end

--- a/mspsds-web/db/migrate/20190215121322_fix_incorrect_pretty_ids.rb
+++ b/mspsds-web/db/migrate/20190215121322_fix_incorrect_pretty_ids.rb
@@ -1,7 +1,5 @@
 class FixIncorrectPrettyIds < ActiveRecord::Migration[5.2]
   def change
-    Investigation.all.each do |investigation|
-      investigation.add_pretty_id
-    end
+    Investigation.all.each(&:add_pretty_id)
   end
 end

--- a/mspsds-web/db/schema.rb
+++ b/mspsds-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_12_141002) do
+ActiveRecord::Schema.define(version: 2019_02_15_121322) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Old way is bugged and results in the same ids for many cases. This should re-generate pretty_ids and since the computation is ordered by created_at they should be different. 