### PR TITLE
MSPSDS-877: Use pretty id in urls

### DIFF
--- a/mspsds-web/app/controllers/concerns/corrective_actions_concern.rb
+++ b/mspsds-web/app/controllers/concerns/corrective_actions_concern.rb
@@ -2,7 +2,7 @@ module CorrectiveActionsConcern
   extend ActiveSupport::Concern
 
   def set_investigation
-    @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id])
+    @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
     authorize @investigation, :show?
   end
 

--- a/mspsds-web/app/controllers/investigations/activities_controller.rb
+++ b/mspsds-web/app/controllers/investigations/activities_controller.rb
@@ -62,7 +62,7 @@ private
   end
 
   def set_investigation
-    @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id])
+    @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
     authorize @investigation, :show?
   end
 

--- a/mspsds-web/app/controllers/investigations/businesses_controller.rb
+++ b/mspsds-web/app/controllers/investigations/businesses_controller.rb
@@ -55,7 +55,7 @@ private
   end
 
   def set_investigation
-    @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id])
+    @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
     authorize @investigation, :show?
   end
 end

--- a/mspsds-web/app/controllers/investigations/correspondence_controller.rb
+++ b/mspsds-web/app/controllers/investigations/correspondence_controller.rb
@@ -49,7 +49,7 @@ private
   end
 
   def set_investigation
-    @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id])
+    @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
     authorize @investigation, :show?
   end
 

--- a/mspsds-web/app/controllers/investigations/products_controller.rb
+++ b/mspsds-web/app/controllers/investigations/products_controller.rb
@@ -56,7 +56,7 @@ private
   end
 
   def set_investigation
-    @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id])
+    @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
     authorize @investigation, :show?
   end
 end

--- a/mspsds-web/app/controllers/investigations_controller.rb
+++ b/mspsds-web/app/controllers/investigations_controller.rb
@@ -118,13 +118,13 @@ private
     @investigation = Investigation.eager_load(:source,
                                               products: { documents_attachments: :blob },
                                               investigation_businesses: { business: :locations },
-                                              documents_attachments: :blob).find_by(pretty_id: params[:pretty_id])
+                                              documents_attachments: :blob).find_by!(pretty_id: params[:pretty_id])
     authorize @investigation, :show?
     preload_activities
   end
 
   def set_investigation
-    @investigation = Investigation.find_by(pretty_id: params[:pretty_id])
+    @investigation = Investigation.find_by!(pretty_id: params[:pretty_id])
     authorize @investigation
   end
 

--- a/mspsds-web/app/helpers/documents_helper.rb
+++ b/mspsds-web/app/helpers/documents_helper.rb
@@ -3,7 +3,7 @@ module DocumentsHelper
   include Pundit
 
   def set_parent
-    @parent = Investigation.find_by(pretty_id: params[:investigation_pretty_id]) if params[:investigation_pretty_id]
+    @parent = Investigation.find_by!(pretty_id: params[:investigation_pretty_id]) if params[:investigation_pretty_id]
     @parent = Product.find(params[:product_id]) if params[:product_id]
     @parent = Business.find(params[:business_id]) if params[:business_id]
     authorize @parent, :show? if @parent.is_a? Investigation

--- a/mspsds-web/app/helpers/tests_helper.rb
+++ b/mspsds-web/app/helpers/tests_helper.rb
@@ -1,6 +1,6 @@
 module TestsHelper
   def set_investigation
-    @investigation = Investigation.find_by(pretty_id: params[:investigation_pretty_id])
+    @investigation = Investigation.find_by!(pretty_id: params[:investigation_pretty_id])
     authorize @investigation, :show?
   end
 

--- a/mspsds-web/app/helpers/url_helper.rb
+++ b/mspsds-web/app/helpers/url_helper.rb
@@ -28,7 +28,7 @@ module UrlHelper
     case_id = request.referer&.match(/cases\/(\d+-\d+)/)&.captures&.first
     return nil if case_id.blank?
 
-    investigation = Investigation.find_by(pretty_id: case_id)
+    investigation = Investigation.find_by!(pretty_id: case_id)
     {
       is_simple_link: true,
       link_text: "Back to #{investigation.pretty_description}",

--- a/mspsds-web/app/models/investigation.rb
+++ b/mspsds-web/app/models/investigation.rb
@@ -195,7 +195,7 @@ class Investigation < ApplicationRecord
   end
 
   def add_pretty_id(id: nil)
-    id = id || Investigation.where("created_at < ?", created_at).where("created_at > ?", created_at.beginning_of_month).count
+    id = id || Investigation.where("created_at < ? AND created_at > ?", created_at, created_at.beginning_of_month).count
     pretty_id = "#{created_at.strftime('%y%m')}-%04d" % id
     self.pretty_id = pretty_id
   end

--- a/mspsds-web/app/models/investigation.rb
+++ b/mspsds-web/app/models/investigation.rb
@@ -7,8 +7,6 @@ class Investigation < ApplicationRecord
   attr_accessor :status_rationale
   attr_accessor :visibility_rationale
 
-  scope :this_month, -> { where(created_at: Time.zone.now.beginning_of_month..Time.zone.now.end_of_month) }
-
   validates :user_title, presence: true, on: :enquiry_details
   validates :description, presence: true, on: %i[allegation_details enquiry_details]
   validates :hazard_type, presence: true, on: :allegation_details
@@ -196,7 +194,8 @@ class Investigation < ApplicationRecord
     pretty_id
   end
 
-  def add_pretty_id(id: Investigation.this_month.where("created_at < ?", created_at).count)
+  def add_pretty_id(id: nil)
+    id = id || Investigation.where("created_at < ?", created_at).where("created_at > ?", created_at.beginning_of_month).count
     pretty_id = "#{created_at.strftime('%y%m')}-%04d" % id
     self.pretty_id = pretty_id
   end

--- a/mspsds-web/app/models/investigation.rb
+++ b/mspsds-web/app/models/investigation.rb
@@ -194,10 +194,9 @@ class Investigation < ApplicationRecord
     pretty_id
   end
 
-  def add_pretty_id(id: nil)
-    id = id || Investigation.where("created_at < ? AND created_at > ?", created_at, created_at.beginning_of_month).count
-    pretty_id = "#{created_at.strftime('%y%m')}-%04d" % id
-    self.pretty_id = pretty_id
+  def add_pretty_id
+    cases_before = Investigation.where("created_at < ? AND created_at > ?", created_at, created_at.beginning_of_month).count
+    self.pretty_id = "#{created_at.strftime('%y%m')}-%04d" % (cases_before + 1)
   end
 
 private

--- a/mspsds-web/app/models/investigation.rb
+++ b/mspsds-web/app/models/investigation.rb
@@ -196,7 +196,7 @@ class Investigation < ApplicationRecord
     pretty_id
   end
 
-  def add_pretty_id(id: Investigation.this_month.where.not(pretty_id: nil).count)
+  def add_pretty_id(id: Investigation.this_month.where("created_at < ?", created_at).count)
     pretty_id = "#{created_at.strftime('%y%m')}-%04d" % id
     self.pretty_id = pretty_id
   end

--- a/mspsds-web/app/views/investigations/index.xlsx.axlsx
+++ b/mspsds-web/app/views/investigations/index.xlsx.axlsx
@@ -15,7 +15,7 @@ book.add_worksheet name: "Cases" do |sheet_investigations|
         investigation.description,
         investigation.product_category,
         investigation.hazard_type,
-        investigation.assignee ? investigation.assignee.email : "Unassigned",
+        investigation.assignee ? investigation.assignee.display_name : "Unassigned",
         investigation.source&.show,
         complainant.present? ? (complainant.can_be_displayed? ? complainant&.name : "Restricted") : "",
         complainant.present? ? (complainant.can_be_displayed? ? complainant&.email_address : "Restricted") : "",

--- a/mspsds-web/app/views/investigations/show.pdf.slim
+++ b/mspsds-web/app/views/investigations/show.pdf.slim
@@ -20,7 +20,7 @@ table[style="width:100%; text-align:left"]
     th
       | Assignee
     td
-      = @investigation.assignee.nil? ? "Unassigned" : @investigation.assignee.email
+      = @investigation.assignee.nil? ? "Unassigned" : @investigation.assignee.display_name
   tr
     th
       | Source

--- a/mspsds-web/db/migrate/20190215121322_fix_incorrect_pretty_ids.rb
+++ b/mspsds-web/db/migrate/20190215121322_fix_incorrect_pretty_ids.rb
@@ -1,0 +1,8 @@
+class FixIncorrectPrettyIds < ActiveRecord::Migration[5.2]
+  def change
+    Investigation.in_batches.each_record do |record|
+      record.add_pretty_id
+      record.save
+    end
+  end
+end

--- a/mspsds-web/db/migrate/20190215121322_fix_incorrect_pretty_ids.rb
+++ b/mspsds-web/db/migrate/20190215121322_fix_incorrect_pretty_ids.rb
@@ -1,0 +1,7 @@
+class FixIncorrectPrettyIds < ActiveRecord::Migration[5.2]
+  def change
+    Investigation.all.each do |investigation|
+      investigation.add_pretty_id
+    end
+  end
+end

--- a/mspsds-web/db/migrate/20190215121322_fix_incorrect_pretty_ids.rb
+++ b/mspsds-web/db/migrate/20190215121322_fix_incorrect_pretty_ids.rb
@@ -1,5 +1,5 @@
 class FixIncorrectPrettyIds < ActiveRecord::Migration[5.2]
   def change
-    Investigation.all.each(&:add_pretty_id)
+    Investigation.in_batches.each(&:add_pretty_id)
   end
 end

--- a/mspsds-web/db/migrate/20190215121322_fix_incorrect_pretty_ids.rb
+++ b/mspsds-web/db/migrate/20190215121322_fix_incorrect_pretty_ids.rb
@@ -1,5 +1,5 @@
 class FixIncorrectPrettyIds < ActiveRecord::Migration[5.2]
   def change
-    Investigation.in_batches.each(&:add_pretty_id)
+    Investigation.in_batches { |relation| relation.each(&:add_pretty_id) }
   end
 end

--- a/mspsds-web/db/migrate/20190215121322_fix_incorrect_pretty_ids.rb
+++ b/mspsds-web/db/migrate/20190215121322_fix_incorrect_pretty_ids.rb
@@ -1,7 +1,5 @@
 class FixIncorrectPrettyIds < ActiveRecord::Migration[5.2]
   def change
-    Investigation.all.each do |investigation|
-      investigation.add_pretty_id
-    end
+    Investigation.all.each(&:add_pretty_id)
   end
 end

--- a/mspsds-web/db/migrate/20190215121322_fix_incorrect_pretty_ids.rb
+++ b/mspsds-web/db/migrate/20190215121322_fix_incorrect_pretty_ids.rb
@@ -1,5 +1,5 @@
 class FixIncorrectPrettyIds < ActiveRecord::Migration[5.2]
   def change
-    Investigation.in_batches { |relation| relation.each(&:add_pretty_id) }
+    Investigation.in_batches.each_record(&:add_pretty_id)
   end
 end

--- a/mspsds-web/db/migrate/20190218110830_make_pretty_id_work_with_old_cases.rb
+++ b/mspsds-web/db/migrate/20190218110830_make_pretty_id_work_with_old_cases.rb
@@ -1,5 +1,0 @@
-class MakePrettyIdWorkWithOldCases < ActiveRecord::Migration[5.2]
-  def change
-    Investigation.in_batches.each_record(&:add_pretty_id)
-  end
-end

--- a/mspsds-web/db/migrate/20190218110830_make_pretty_id_work_with_old_cases.rb
+++ b/mspsds-web/db/migrate/20190218110830_make_pretty_id_work_with_old_cases.rb
@@ -1,4 +1,4 @@
-class FixIncorrectPrettyIds < ActiveRecord::Migration[5.2]
+class MakePrettyIdWorkWithOldCases < ActiveRecord::Migration[5.2]
   def change
     Investigation.in_batches.each_record(&:add_pretty_id)
   end

--- a/mspsds-web/db/schema.rb
+++ b/mspsds-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_12_141002) do
+ActiveRecord::Schema.define(version: 2019_02_15_121322) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/mspsds-web/db/schema.rb
+++ b/mspsds-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_18_110830) do
+ActiveRecord::Schema.define(version: 2019_02_15_121322) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/mspsds-web/db/schema.rb
+++ b/mspsds-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_15_121322) do
+ActiveRecord::Schema.define(version: 2019_02_18_110830) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Last version worked great with cases from current month, but not so great with cases from before current month. 

I can't really understand the results I got by running the old migration on int, the current month ids don't seem to be in the right order(when sorting by created_at), the older ones all use the count of 5(count of cases from current month), except for one that uses 4. 

Maybe having 2 conditions on the same field in different wheres with different types doesn't generate the query the way I thought it does :( 

In any case, this should make case ids unique for older months, migration works for the limited dataset I have locally. 