### PR TITLE
MSPSDS-6 Turn on polling in file watch for webpack

### DIFF
--- a/mspsds-web/config/webpacker.yml
+++ b/mspsds-web/config/webpacker.yml
@@ -69,6 +69,7 @@ development:
     headers:
       'Access-Control-Allow-Origin': '*'
     watch_options:
+      poll: true
       ignored: '**/node_modules/**'
 
 


### PR DESCRIPTION
Without this option enabled watching does not seem to work, at least
not on Windows machines.
https://webpack.js.org/configuration/watch/#watchoptionspoll gives
some examples of systems where that is the found behaviour - presumably
our windows-docker set up falls into the same bucket.