### PR TITLE
COSBETA-NONE: Extend Travis timeout to allow web deployments to finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,37 +46,37 @@ jobs:
 
     - stage: Deploy to int
       name: Deploy MSPSDS web
-      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=mspsds-web ./ci/deploy-if-changed.sh
+      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=mspsds-web travis_wait ./ci/deploy-if-changed.sh
     - name: Deploy MSPSDS worker
       script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=mspsds-worker ./ci/deploy-if-changed.sh
     - name: Deploy Keycloak
       script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=keycloak ./ci/deploy-if-changed.sh
     - name: Deploy Cosmetics web
-      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=cosmetics-web ./ci/deploy-if-changed.sh
+      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=cosmetics-web travis_wait ./ci/deploy-if-changed.sh
     - name: Deploy Cosmetics worker
       script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=int COMPONENT=cosmetics-worker ./ci/deploy-if-changed.sh
 
     - stage: Deploy to staging
       name: Deploy MSPSDS web
-      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=mspsds-web ./ci/deploy-if-changed.sh
+      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=mspsds-web travis_wait ./ci/deploy-if-changed.sh
     - name: Deploy MSPSDS worker
       script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=mspsds-worker ./ci/deploy-if-changed.sh
     - name: Deploy Keycloak
       script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=keycloak ./ci/deploy-if-changed.sh
     - name: Deploy Cosmetics web
-      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=cosmetics-web ./ci/deploy-if-changed.sh
+      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=cosmetics-web travis_wait ./ci/deploy-if-changed.sh
     - name: Deploy Cosmetics worker
       script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=staging COMPONENT=cosmetics-worker ./ci/deploy-if-changed.sh
 
     - stage: Deploy to production
       name: Deploy MSPSDS web
-      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=prod COMPONENT=mspsds-web ./ci/deploy-if-changed.sh
+      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=prod COMPONENT=mspsds-web travis_wait ./ci/deploy-if-changed.sh
     - name: Deploy MSPSDS worker
       script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=prod COMPONENT=mspsds-worker ./ci/deploy-if-changed.sh
     - name: Deploy Keycloak
       script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=prod COMPONENT=keycloak ./ci/deploy-if-changed.sh
     - name: Deploy Cosmetics web
-      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=prod COMPONENT=cosmetics-web ./ci/deploy-if-changed.sh
+      script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=prod COMPONENT=cosmetics-web travis_wait ./ci/deploy-if-changed.sh
     - name: Deploy Cosmetics worker
       script: BRANCH=${TRAVIS_BRANCH} BUILD_ID=${TRAVIS_BUILD_NUMBER} SPACE=prod COMPONENT=cosmetics-worker ./ci/deploy-if-changed.sh
 


### PR DESCRIPTION
Travis builds timeout if commands do not produce any output for 10 minutes, which can be the case when assets are being compiled during web deployments. Using the travis_wait function extends that limit to 20 minutes. For details, see:
https://docs.travis-ci.com/user/common-build-problems#build-times-out-because-no-output-was-received