### PR TITLE
COSBETA-33: Hopefully fix ES crashes when updating a notification on int

### DIFF
--- a/cosmetics-web/db/schema.rb
+++ b/cosmetics-web/db/schema.rb
@@ -138,7 +138,6 @@ ActiveRecord::Schema.define(version: 2019_03_05_143843) do
 
   create_table "pending_responsible_person_users", force: :cascade do |t|
     t.string "email_address"
-    t.string "key"
     t.datetime "expires_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/mspsds-web/app/models/concerns/searchable.rb
+++ b/mspsds-web/app/models/concerns/searchable.rb
@@ -5,6 +5,13 @@ module Searchable
   included do
     include Shared::Web::Concerns::Searchable
 
+    # TODO: These lines fix the issue of not updating the updated_at in Elasticsearch.
+    # Same issue is pointed out in the following link. We can remove it once that PR is merged.
+    # https://github.com/elastic/elasticsearch-rails/pull/703
+    after_update do |document|
+      document.__elasticsearch__.update_document_attributes updated_at: document.updated_at
+    end
+
     def self.full_search(query)
       # This line makes sure elasticsearch index is recreated before we search
       # It fixes the issue of getting no results the first time case list page is loaded

--- a/shared-web/app/models/shared/web/concerns/searchable.rb
+++ b/shared-web/app/models/shared/web/concerns/searchable.rb
@@ -59,13 +59,6 @@ module Shared
               }
             ]
           end
-
-          # TODO: These lines fix the issue of not updating the updated_at in Elasticsearch.
-          # Same issue is pointed out in the following link. We can remove it once that PR is merged.
-          # https://github.com/elastic/elasticsearch-rails/pull/703
-          after_update do |document|
-            document.__elasticsearch__.update_document_attributes updated_at: document.updated_at
-          end
         end
       end
     end


### PR DESCRIPTION
Shared web searchable.rb included a piece that made sure 'updated_at' was updated correctly, in a after_update hook. This in conjunction with us not indexing incomplete notifications caused crashes whenever a draft or incomplete notification was updated. 

Since we actually don't want to index records by updated_at(yet), the simplest solution is to just move the hook into mspsds-web. 

## Checklist:
- [x] Automated checks are passing locally.
- [x] CHANGELOG updated if change is worth telling users about.