### PR TITLE
COSBETA-57: Validate phone registration

### DIFF
--- a/keycloak/providers/registration-form/src/main/java/uk/gov/beis/mspsds/keycloak/providers/RegistrationMobileNumber.java
+++ b/keycloak/providers/registration-form/src/main/java/uk/gov/beis/mspsds/keycloak/providers/RegistrationMobileNumber.java
@@ -61,7 +61,7 @@ public class RegistrationMobileNumber implements FormAction {
         } else if (isInternationalNumber(formattedPhoneNumber)) {
             region = null;
         } else {
-            return true; // If the number cannot be interpreted as an international or possible UK phone number, do not attempt to validate it.
+            return false; // If the number cannot be interpreted as an international or possible UK phone number, do not attempt to validate it.
         }
 
         try {

--- a/keycloak/providers/registration-form/src/main/java/uk/gov/beis/mspsds/keycloak/providers/RegistrationMobileNumber.java
+++ b/keycloak/providers/registration-form/src/main/java/uk/gov/beis/mspsds/keycloak/providers/RegistrationMobileNumber.java
@@ -66,7 +66,9 @@ public class RegistrationMobileNumber implements FormAction {
 
         try {
             PhoneNumber parsedPhoneNumber = PhoneNumberUtil.getInstance().parse(formattedPhoneNumber, region);
-            return PhoneNumberUtil.getInstance().isValidNumber(parsedPhoneNumber);
+            boolean isValidNumber = PhoneNumberUtil.getInstance().isValidNumber(parsedPhoneNumber);
+            boolean isFixedLineOrMobile = isFixedLineOrMobile(parsedPhoneNumber);
+            return isValidNumber && isFixedLineOrMobile;
         } catch (NumberParseException e) {
             return false;
         }
@@ -86,6 +88,13 @@ public class RegistrationMobileNumber implements FormAction {
 
     private static boolean isInternationalNumber(String phoneNumber) {
         return phoneNumber.trim().startsWith("+");
+    }
+
+    private static boolean isFixedLineOrMobile(PhoneNumber phoneNumber) {
+        PhoneNumberUtil.PhoneNumberType phoneNumberType = PhoneNumberUtil.getInstance().getNumberType(phoneNumber);
+        boolean isMobile = phoneNumberType == PhoneNumberUtil.PhoneNumberType.MOBILE;
+        boolean isFixedLineOrMobile = phoneNumberType == PhoneNumberUtil.PhoneNumberType.FIXED_LINE_OR_MOBILE;
+        return isMobile || isFixedLineOrMobile;
     }
 
     @Override

--- a/keycloak/providers/registration-form/src/main/java/uk/gov/beis/mspsds/keycloak/providers/RegistrationMobileNumber.java
+++ b/keycloak/providers/registration-form/src/main/java/uk/gov/beis/mspsds/keycloak/providers/RegistrationMobileNumber.java
@@ -56,7 +56,7 @@ public class RegistrationMobileNumber implements FormAction {
         String formattedPhoneNumber = convertInternationalPrefix(phoneNumber);
 
         String region;
-        if (isPossibleNationalNumber(formattedPhoneNumber)) {
+        if (isPossibleNationalMobileNumber(formattedPhoneNumber)) {
             region = "GB";
         } else if (isInternationalNumber(formattedPhoneNumber)) {
             region = null;
@@ -80,7 +80,7 @@ public class RegistrationMobileNumber implements FormAction {
         return trimmedPhoneNumber;
     }
 
-    private static boolean isPossibleNationalNumber(String phoneNumber) {
+    private static boolean isPossibleNationalMobileNumber(String phoneNumber) {
         return phoneNumber.trim().startsWith("+44") || phoneNumber.trim().startsWith("07");
     }
 


### PR DESCRIPTION
Fixes a bug where users could provide invalid phone number.

Changes a returned value of `isPhoneNumberValid` to false when it cannot be interpreted as an international or possible UK phone number. It used to be true, which allowed pretty much any badly invalid number to go through. 

## Checklist:
- [x] Automated checks are passing locally.