### PR TITLE
COSBETA-174: Include redirect URI in Keycloak registration URL

### DIFF
--- a/shared-web/app/clients/shared/web/keycloak_client.rb
+++ b/shared-web/app/clients/shared/web/keycloak_client.rb
@@ -111,8 +111,9 @@ module Shared
         JSON.parse(response)
       end
 
-      def registration_url
-        Keycloak::Client.auth_server_url + "/realms/#{Keycloak::Client.realm}/protocol/openid-connect/registrations?client_id=#{Keycloak::Client.client_id}&response_type=code"
+      def registration_url(redirect_uri)
+        params = URI.encode_www_form(client_id: Keycloak::Client.client_id, response_type: "code", redirect_uri: redirect_uri)
+        Keycloak::Client.auth_server_url + "/realms/#{Keycloak::Client.realm}/protocol/openid-connect/registrations?#{params}"
       end
 
       def login_url(redirect_uri)

--- a/shared-web/app/helpers/shared/web/login_helper.rb
+++ b/shared-web/app/helpers/shared/web/login_helper.rb
@@ -5,8 +5,8 @@ module Shared
         Shared::Web::KeycloakClient.instance.login_url(get_session_url_with_redirect(request_path))
       end
 
-      def keycloak_registration_url
-        Shared::Web::KeycloakClient.instance.registration_url
+      def keycloak_registration_url(request_path = nil)
+        Shared::Web::KeycloakClient.instance.registration_url(get_session_url_with_redirect(request_path))
       end
 
       def login_page?


### PR DESCRIPTION
This should ensure that the user is correctly signed in and directed back to the service after clicking the link in the verification email.