### PR TITLE
MSPSDS-1047 Make keycloak test mocking setup better

### DIFF
--- a/mspsds-web/test/controllers/activities_controller_test.rb
+++ b/mspsds-web/test/controllers/activities_controller_test.rb
@@ -2,14 +2,14 @@ require "test_helper"
 
 class ActivitiesControllerTest < ActionDispatch::IntegrationTest
   setup do
-    sign_in_as_admin
+    mock_out_keycloak_and_notify(user_name: "Admin")
     @investigation = investigations(:one)
     @activity = activities(:one)
     @activity.source = sources(:activity_one)
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "should create activity" do

--- a/mspsds-web/test/controllers/businesses_controller_test.rb
+++ b/mspsds-web/test/controllers/businesses_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class BusinessesControllerTest < ActionDispatch::IntegrationTest
   setup do
-    sign_in_as_admin
+    mock_out_keycloak_and_notify(user_name: "Admin")
     @business_one = businesses(:one)
     @business_two = businesses(:two)
     @business_one.source = sources(:business_one)
@@ -11,7 +11,7 @@ class BusinessesControllerTest < ActionDispatch::IntegrationTest
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "should get index" do

--- a/mspsds-web/test/controllers/contacts_controller_test.rb
+++ b/mspsds-web/test/controllers/contacts_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class ContactsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    sign_in_as_admin
+    mock_out_keycloak_and_notify(user_name: "Admin")
     @contact = contacts(:one)
   end
 

--- a/mspsds-web/test/controllers/errors_controller_test.rb
+++ b/mspsds-web/test/controllers/errors_controller_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 
 class ErrorsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    sign_in_as_admin
+    mock_out_keycloak_and_notify(user_name: "Admin")
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "should get not_found" do

--- a/mspsds-web/test/controllers/homepage_controller_test.rb
+++ b/mspsds-web/test/controllers/homepage_controller_test.rb
@@ -1,18 +1,21 @@
 require "test_helper"
 
 class HomepageControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    mock_out_keycloak_and_notify
+  end
+
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "displays homepage for non_opss users" do
-    sign_in_as_non_opss_user
+    set_user_as_non_opss(User.current)
     get "/"
     assert_response :success
   end
 
   test "redirects to /cases for opss users" do
-    sign_in_as_user
     get "/"
     assert_redirected_to investigations_path
   end

--- a/mspsds-web/test/controllers/investigations/corrective_actions_controller_test.rb
+++ b/mspsds-web/test/controllers/investigations/corrective_actions_controller_test.rb
@@ -5,11 +5,11 @@ class CorrectiveActionsControllerTest < ActionDispatch::IntegrationTest
     @investigation = investigations(:one)
     @business = businesses(:one)
     @product = products(:one)
-    sign_in_as_user
+    mock_out_keycloak_and_notify
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "should redirect new corrective action request to first wizard step" do

--- a/mspsds-web/test/controllers/investigations/products_controller_test.rb
+++ b/mspsds-web/test/controllers/investigations/products_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Investigations::ProductsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    sign_in_as_admin
+    mock_out_keycloak_and_notify(user_name: "Admin")
     @investigation = investigations(:one)
     @investigation.source = sources(:investigation_one)
     @product = products(:iphone)
@@ -10,7 +10,7 @@ class Investigations::ProductsControllerTest < ActionDispatch::IntegrationTest
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "should get new" do

--- a/mspsds-web/test/controllers/investigations/tests_controller_test.rb
+++ b/mspsds-web/test/controllers/investigations/tests_controller_test.rb
@@ -4,11 +4,11 @@ class TestsControllerTest < ActionDispatch::IntegrationTest
   setup do
     @investigation = investigations(:one)
     @product = products(:one)
-    sign_in_as_user
+    mock_out_keycloak_and_notify
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "should redirect new test request action to first wizard step" do

--- a/mspsds-web/test/controllers/investigations_xls_export_test.rb
+++ b/mspsds-web/test/controllers/investigations_xls_export_test.rb
@@ -2,11 +2,11 @@ require "test_helper"
 
 class InvestigationsXlsExportTest < ActionDispatch::IntegrationTest
   setup do
-    sign_in_as_admin
+    mock_out_keycloak_and_notify(user_name: "Admin")
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "exports all investigations" do

--- a/mspsds-web/test/controllers/locations_controller_test.rb
+++ b/mspsds-web/test/controllers/locations_controller_test.rb
@@ -2,13 +2,13 @@ require "test_helper"
 
 class LocationsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    sign_in_as_admin
+    mock_out_keycloak_and_notify(user_name: "Admin")
     @location = locations(:one)
     @location.source = sources(:location_one)
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "should get new" do

--- a/mspsds-web/test/controllers/products_controller_test.rb
+++ b/mspsds-web/test/controllers/products_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class ProductsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    sign_in_as_user
+    mock_out_keycloak_and_notify
     @product_one = products(:one)
     @product_one.source = sources(:product_one)
     @product_iphone = products(:iphone)
@@ -15,7 +15,7 @@ class ProductsControllerTest < ActionDispatch::IntegrationTest
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "should get index" do

--- a/mspsds-web/test/controllers/team_test.rb
+++ b/mspsds-web/test/controllers/team_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class TeamTest < ActionDispatch::IntegrationTest
   setup do
-    sign_in_as_user
+    mock_out_keycloak_and_notify
 
     @user_one = User.find_by(last_name: "User_one")
     @user_two = User.find_by(last_name: "User_two")
@@ -13,7 +13,7 @@ class TeamTest < ActionDispatch::IntegrationTest
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "team users can see each other by get team members" do

--- a/mspsds-web/test/models/complainant_test.rb
+++ b/mspsds-web/test/models/complainant_test.rb
@@ -3,11 +3,11 @@ require "test_helper"
 class ComplainantTest < ActiveSupport::TestCase
   setup do
     @complainant = Complainant.new(complainant_type: "Business")
-    sign_in_as_user
+    mock_out_keycloak_and_notify
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "should not allow complainant without an investigation" do

--- a/mspsds-web/test/models/corrective_action_test.rb
+++ b/mspsds-web/test/models/corrective_action_test.rb
@@ -5,7 +5,7 @@ class CorrectiveActionTest < ActiveSupport::TestCase
     @investigation = investigations(:one)
     @business = businesses(:one)
     @product = products(:one)
-    sign_in_as_user
+    mock_out_keycloak_and_notify
   end
 
   test "requires an associated investigation, business and product" do

--- a/mspsds-web/test/models/investigation_test.rb
+++ b/mspsds-web/test/models/investigation_test.rb
@@ -8,7 +8,7 @@ class InvestigationTest < ActiveSupport::TestCase
   end
 
   setup do
-    sign_in_as_user
+    mock_out_keycloak_and_notify
     @investigation = investigations(:one)
 
     @investigation_with_product = investigations(:search_related_products)
@@ -25,7 +25,7 @@ class InvestigationTest < ActiveSupport::TestCase
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "should create activities when investigation is created" do
@@ -202,11 +202,9 @@ class InvestigationTest < ActiveSupport::TestCase
 
   test "not visible to no-admin, no-source, no-assignee organisation" do
     create_new_private_case
-    logout
-    sign_in_as_non_opss_user(user_name: "User_two")
-    user = User.find_by(last_name: "User_two")
-    set_user_as_non_opss(user)
-    assert_not(policy(@new_investigation).show?(user: user))
+    sign_in_as User.find_by(last_name: "User_two")
+    set_user_as_non_opss(User.current)
+    assert_not(policy(@new_investigation).show?(user: User.current))
   end
 
   test "past assignees should be computed" do

--- a/mspsds-web/test/models/organisation_test.rb
+++ b/mspsds-web/test/models/organisation_test.rb
@@ -2,8 +2,6 @@ require "test_helper"
 
 class OrganisationTest < ActiveSupport::TestCase
   setup do
-    sign_in_as_user
-
     @organisations = [
       { id: "def4eef8-1a33-4322-8b8c-fc7fa95a2e3b", name: "Organisation 1", path: "/Organisations/Organisation 1", subGroups: [] },
       { id: "1a612aea-1d3d-47ee-8c3a-76b4448bb97b", name: "Organisation 2", path: "/Organisations/Organisation 2", subGroups: [] },
@@ -19,16 +17,18 @@ class OrganisationTest < ActiveSupport::TestCase
   end
 
   teardown do
-    logout
+    allow(Keycloak::Internal).to receive(:get_groups).and_call_original
   end
 
   test "all Keycloak organisations are added" do
+    Rails.cache.delete(:keycloak_groups)
     all_organisations = Organisation.all
 
     assert_same_elements @organisations.map { |org| org[:id] }, all_organisations.pluck(:id)
   end
 
   test "all organisation properties are populated" do
+    Rails.cache.delete(:keycloak_groups)
     all_organisations = Organisation.all
 
     assert_same_elements @organisations.map { |org| org[:name] }, all_organisations.pluck(:name)
@@ -36,6 +36,7 @@ class OrganisationTest < ActiveSupport::TestCase
   end
 
   test "all non-organisation groups are excluded" do
+    Rails.cache.delete(:keycloak_groups)
     all_organisations = Organisation.all
 
     assert_not_includes all_organisations.pluck(:name), "Group 1"

--- a/mspsds-web/test/models/test_test.rb
+++ b/mspsds-web/test/models/test_test.rb
@@ -4,11 +4,11 @@ class TestTest < ActiveSupport::TestCase
   setup do
     @investigation = investigations(:one)
     @product = products(:one)
-    sign_in_as_user
+    mock_out_keycloak_and_notify
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "requires an associated investigation and product" do

--- a/mspsds-web/test/system/activity_entry_test.rb
+++ b/mspsds-web/test/system/activity_entry_test.rb
@@ -2,14 +2,14 @@ require "application_system_test_case"
 
 class ActivityEntryTest < ApplicationSystemTestCase
   setup do
-    sign_in_as_admin
+    mock_out_keycloak_and_notify(user_name: "Admin")
     @investigation = investigations(:one)
     visit investigation_path(@investigation)
     click_on "Add activity"
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "Should go to an activity selection page" do

--- a/mspsds-web/test/system/breadcrumb_test.rb
+++ b/mspsds-web/test/system/breadcrumb_test.rb
@@ -2,7 +2,7 @@ require "application_system_test_case"
 
 class BreadcrumbTest < ApplicationSystemTestCase
   setup do
-    sign_in_as_admin
+    mock_out_keycloak_and_notify(user_name: "Admin")
     @investigation_products = investigations(:search_related_products)
     @product = @investigation_products.products.first
     @investigation_businesses = investigations(:search_related_businesses)
@@ -10,7 +10,7 @@ class BreadcrumbTest < ApplicationSystemTestCase
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "when accessing product page from case page navigation should let you go back to the case" do

--- a/mspsds-web/test/system/corrective_actions_test.rb
+++ b/mspsds-web/test/system/corrective_actions_test.rb
@@ -4,7 +4,7 @@ require_relative "../test_helpers/corrective_action_test_helper"
 class CorrectiveActionsTest < ApplicationSystemTestCase
   include CorrectiveActionTestHelper
   setup do
-    sign_in_as_user
+    mock_out_keycloak_and_notify
 
     @investigation = investigations(:one)
     @corrective_action = corrective_actions(:one)
@@ -14,7 +14,7 @@ class CorrectiveActionsTest < ApplicationSystemTestCase
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "can record corrective action for a case" do

--- a/mspsds-web/test/system/create_allegation_test.rb
+++ b/mspsds-web/test/system/create_allegation_test.rb
@@ -15,12 +15,12 @@ class CreateAllegationTest < ApplicationSystemTestCase
       description: "Allegation description"
     )
 
-    sign_in_as_user
+    mock_out_keycloak_and_notify
     visit new_allegation_path
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "can be reached via create page" do

--- a/mspsds-web/test/system/create_enquiry_test.rb
+++ b/mspsds-web/test/system/create_enquiry_test.rb
@@ -14,12 +14,12 @@ class CreateEnquiryTest < ApplicationSystemTestCase
       description: "Enquiry description"
     )
 
-    sign_in_as_user
+    mock_out_keycloak_and_notify
     visit new_enquiry_path
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "can be reached via create page" do

--- a/mspsds-web/test/system/create_new_record_test.rb
+++ b/mspsds-web/test/system/create_new_record_test.rb
@@ -2,12 +2,12 @@ require "application_system_test_case"
 
 class CreateNewRecordTest < ApplicationSystemTestCase
   setup do
-    sign_in_as_user
+    mock_out_keycloak_and_notify
     visit new_investigation_path
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "can be reached via home page" do

--- a/mspsds-web/test/system/create_project_test.rb
+++ b/mspsds-web/test/system/create_project_test.rb
@@ -3,12 +3,12 @@ require "application_system_test_case"
 class CreateProjectTest < ApplicationSystemTestCase
   setup do
     @project = Investigation::Project.new(description: "new project description", user_title: "project title")
-    sign_in_as_user
+    mock_out_keycloak_and_notify
     visit new_project_path
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "can be reached via create page" do

--- a/mspsds-web/test/system/create_ts_investigation_test.rb
+++ b/mspsds-web/test/system/create_ts_investigation_test.rb
@@ -6,7 +6,8 @@ class CreateTsInvestigationTest < ApplicationSystemTestCase
   include CorrectiveActionTestHelper
 
   setup do
-    sign_in_as_non_opss_user
+    mock_out_keycloak_and_notify
+    set_user_as_non_opss(User.current)
 
     @product = products(:one)
     @investigation = investigations(:one)
@@ -20,7 +21,7 @@ class CreateTsInvestigationTest < ApplicationSystemTestCase
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "can complete the ts flow" do

--- a/mspsds-web/test/system/document_test.rb
+++ b/mspsds-web/test/system/document_test.rb
@@ -3,13 +3,13 @@ require "application_system_test_case"
 class DocumentTest < ApplicationSystemTestCase
   include UrlHelper
   setup do
-    sign_in_as_user
+    mock_out_keycloak_and_notify
 
     visit new_document_flow_path(investigations(:no_products))
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "First step should be file upload" do

--- a/mspsds-web/test/system/investigation_assignee_test.rb
+++ b/mspsds-web/test/system/investigation_assignee_test.rb
@@ -2,14 +2,14 @@ require "application_system_test_case"
 
 class InvestigationAssigneeTest < ApplicationSystemTestCase
   setup do
-    sign_in_as_user
-    @user = User.find_by(last_name: "User_one")
+    mock_out_keycloak_and_notify
+    @user = User.current
     @team = @user.teams.first
     visit assign_investigation_path(investigations(:one))
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "should show current user as a radio, and to assign user to case" do

--- a/mspsds-web/test/system/investigation_business_test.rb
+++ b/mspsds-web/test/system/investigation_business_test.rb
@@ -2,7 +2,7 @@ require "application_system_test_case"
 
 class InvestigationBusinessTest < ApplicationSystemTestCase
   setup do
-    sign_in_as_user
+    mock_out_keycloak_and_notify
     @investigation = investigations(:one)
     @business = businesses(:three)
     @business.source = sources(:business_three)
@@ -12,7 +12,7 @@ class InvestigationBusinessTest < ApplicationSystemTestCase
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "create a business on investigation" do

--- a/mspsds-web/test/system/investigation_highlight_test.rb
+++ b/mspsds-web/test/system/investigation_highlight_test.rb
@@ -2,12 +2,12 @@ require "application_system_test_case"
 
 class InvestigationHighlightTest < ApplicationSystemTestCase
   setup do
-    sign_in_as_user
+    mock_out_keycloak_and_notify
     visit root_path
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "should display highlight title" do

--- a/mspsds-web/test/system/investigation_test_request_test.rb
+++ b/mspsds-web/test/system/investigation_test_request_test.rb
@@ -2,7 +2,7 @@ require "application_system_test_case"
 
 class InvestigationTestRequestTest < ApplicationSystemTestCase
   setup do
-    sign_in_as_user
+    mock_out_keycloak_and_notify
 
     @investigation = investigations(:one)
     @test = tests(:one)
@@ -12,7 +12,7 @@ class InvestigationTestRequestTest < ApplicationSystemTestCase
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "cannot add test request without a date" do

--- a/mspsds-web/test/system/investigation_test_result_test.rb
+++ b/mspsds-web/test/system/investigation_test_result_test.rb
@@ -2,7 +2,7 @@ require "application_system_test_case"
 
 class InvestigationTestResultTest < ApplicationSystemTestCase
   setup do
-    sign_in_as_user
+    mock_out_keycloak_and_notify
 
     @investigation = investigations(:one)
     @test = tests(:one)
@@ -12,7 +12,7 @@ class InvestigationTestResultTest < ApplicationSystemTestCase
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "cannot add test result without a date or result" do

--- a/mspsds-web/test/system/record_email_correspondence_test.rb
+++ b/mspsds-web/test/system/record_email_correspondence_test.rb
@@ -2,7 +2,7 @@ require "application_system_test_case"
 
 class RecordEmailCorrespondenceTest < ApplicationSystemTestCase
   setup do
-    sign_in_as_admin
+    mock_out_keycloak_and_notify(user_name: "Admin")
     @investigation = investigations(:one)
     @investigation.source = sources(:investigation_one)
     @correspondence = correspondences(:email)
@@ -10,7 +10,7 @@ class RecordEmailCorrespondenceTest < ApplicationSystemTestCase
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "first step should be context" do

--- a/mspsds-web/test/system/record_meeting_correspondence_test.rb
+++ b/mspsds-web/test/system/record_meeting_correspondence_test.rb
@@ -2,7 +2,7 @@ require "application_system_test_case"
 
 class RecordMeetingCorrespondenceTest < ApplicationSystemTestCase
   setup do
-    sign_in_as_admin
+    mock_out_keycloak_and_notify(user_name: "Admin")
     @investigation = investigations(:one)
     @investigation.source = sources(:investigation_one)
     @correspondence = correspondences(:meeting)
@@ -10,7 +10,7 @@ class RecordMeetingCorrespondenceTest < ApplicationSystemTestCase
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "first step is context" do

--- a/mspsds-web/test/system/record_phonecall_correspondence_test.rb
+++ b/mspsds-web/test/system/record_phonecall_correspondence_test.rb
@@ -2,7 +2,7 @@ require "application_system_test_case"
 
 class RecordPhoneCallCorrespondenceTest < ApplicationSystemTestCase
   setup do
-    sign_in_as_admin
+    mock_out_keycloak_and_notify(user_name: "Admin")
     @investigation = investigations(:one)
     @investigation.source = sources(:investigation_one)
     @correspondence = correspondences(:phone_call)
@@ -10,7 +10,7 @@ class RecordPhoneCallCorrespondenceTest < ApplicationSystemTestCase
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "first step should be context" do

--- a/mspsds-web/test/system/update_product_test.rb
+++ b/mspsds-web/test/system/update_product_test.rb
@@ -3,11 +3,11 @@ require "application_system_test_case"
 class UpdateProductTest < ApplicationSystemTestCase
   setup do
     @product = products(:one)
-    sign_in_as_user
+    mock_out_keycloak_and_notify
   end
 
   teardown do
-    logout
+    reset_keycloak_and_notify_mocks
   end
 
   test "edit page fields should be populated with product attributes" do

--- a/mspsds-web/test/test_helper.rb
+++ b/mspsds-web/test/test_helper.rb
@@ -18,6 +18,11 @@ require "rspec/mocks/standalone"
 class ActiveSupport::TestCase
   include ::RSpec::Mocks::ExampleMethods
 
+  def initialize *args
+    @keycloak_client_instance = Shared::Web::KeycloakClient.instance
+    super *args
+  end
+
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all
 
@@ -37,44 +42,62 @@ class ActiveSupport::TestCase
     self.class.import_into_elasticsearch
   end
 
-  def sign_in_as_user(is_admin: false, user_name: "User_one", organisation: opss_organisation, teams: [all_teams[0], all_teams[1]])
-    users = all_users
-    user = users.detect { |u| u.last_name == user_name }
-    user.organisation = organisation
 
-    user_groups = [
-      {
-        id: users[1].id,
-        groups: [opss_organisation[:id], all_teams[0].id, all_teams[1].id]
-      },
-      {
-        id: users[0].id,
-        groups: [opss_organisation[:id], all_teams[0].id]
-      },
-      {
-        id: users[2].id,
-        groups: [opss_organisation[:id], all_teams[1].id]
-      },
-      {
-        id: users[3].id,
-        groups: [opss_organisation[:id], all_teams[2].id, all_teams[3].id]
-      }
+  # On top of mocking out external services, this method also sets the user to an initial,
+  # sensible value, but it should only be run once per test.
+  # To change currently logged in user afterwards call `sign_in_as(...)`
+  def mock_out_keycloak_and_notify(user_name: "User_one", team_admin: false)
+    @users = [admin_user,
+              test_user(name: "User_one", id: "75fda9a1-786d-4ace-ad20-76afa4f39111"),
+              test_user(name: "User_two"),
+              test_user(name: "User_three")].map(&:attributes)
+    @organisations = organisations.map(&:attributes)
+    @teams = all_teams.map(&:attributes)
+    @team_users = [
+        { id: next_id, user_id: @users[1][:id], team_id: all_teams[0].id },
+        { id: next_id, user_id: @users[1][:id], team_id: all_teams[1].id },
+        { id: next_id, user_id: @users[0][:id], team_id: all_teams[0].id },
+        { id: next_id, user_id: @users[2][:id], team_id: all_teams[1].id },
+        { id: next_id, user_id: @users[3][:id], team_id: all_teams[2].id },
+        { id: next_id, user_id: @users[3][:id], team_id: all_teams[3].id }
     ]
 
-    if organisation.present?
-      groups = teams.map(&:id)
-      groups << organisation.id
-      user_groups = user_groups.map { |group| group[:id] == user.id ? { id: user.id, groups: groups } : group }.to_json
-    end
+    allow(@keycloak_client_instance).to receive(:all_organisations) { @organisations }
+    allow(@keycloak_client_instance).to receive(:all_teams) { @teams }
+    allow(@keycloak_client_instance).to receive(:all_team_users) { @team_users }
+    allow(@keycloak_client_instance).to receive(:all_users) { @users }
+    Organisation.all
+    Team.all
+    TeamUser.all
+    User.all
+    user = User.find_by(last_name: user_name)
+    set_user_as_opss(user)
+    set_user_as_team_admin(user) if team_admin
+    sign_in_as user
 
-    is_mspsds_user = organisation.present?
-    is_opss_user = organisation&.name == opss_organisation.name
-
-    stub_user_credentials(user: user, groups: groups, is_admin: is_admin, is_opss: is_opss_user, is_mspsds: is_mspsds_user)
-    stub_user_group_data(user_groups: user_groups, users: users)
-    stub_user_data(users: users)
-    stub_client_config
     stub_notify_mailer
+
+    user
+  end
+
+  def sign_in_as(user)
+    allow(@keycloak_client_instance).to receive(:user_signed_in?).and_return(true)
+    allow(@keycloak_client_instance).to receive(:user_info).and_return(user.attributes)
+    User.current = user
+  end
+
+  def reset_keycloak_and_notify_mocks
+    allow(@keycloak_client_instance).to receive(:has_role?).and_call_original
+    allow(@keycloak_client_instance).to receive(:user_signed_in?).and_call_original
+    allow(@keycloak_client_instance).to receive(:user_info).and_call_original
+    allow(@keycloak_client_instance).to receive(:all_users).and_call_original
+    allow(@keycloak_client_instance).to receive(:all_organisations).and_call_original
+    allow(@keycloak_client_instance).to receive(:all_teams).and_call_original
+    allow(@keycloak_client_instance).to receive(:all_team_users).and_call_original
+    Rails.cache.delete(:keycloak_users)
+
+    allow(NotifyMailer).to receive(:investigation_updated).and_call_original
+    allow(NotifyMailer).to receive(:investigation_created).and_call_original
   end
 
   def stub_notify_mailer
@@ -84,43 +107,26 @@ class ActiveSupport::TestCase
     allow(NotifyMailer).to receive(:investigation_created) { result }
   end
 
-  def sign_in_as_non_mspsds_user
-    sign_in_as_user(user_name: "User_three", organisation: nil)
-  end
-
-  def sign_in_as_non_opss_user(user_name: "User_one")
-    sign_in_as_user(user_name: user_name, organisation: non_opss_organisation)
-  end
-
-  def sign_in_as_admin
-    sign_in_as_user(is_admin: true, user_name: "Admin", organisation: opss_organisation)
-  end
-
   def set_user_as_opss(user)
     user.organisation = opss_organisation
     # Keycloak bases this role on the group membership
-    allow(Keycloak::Internal).to receive(:has_role?).with(user.id, :opss_user).and_return(true)
+    set_kc_user_group(user.id, opss_organisation.id)
+    allow(@keycloak_client_instance).to receive(:has_role?).with(user.id, :opss_user).and_return(true)
   end
 
   def set_user_as_non_opss(user)
     user.organisation = non_opss_organisation
     # Keycloak bases this role on the group membership
-    allow(Keycloak::Internal).to receive(:has_role?).with(user.id, :opss_user).and_return(false)
+    set_kc_user_group(user.id, non_opss_organisation.id)
+    allow(@keycloak_client_instance).to receive(:has_role?).with(user.id, :opss_user).and_return(false)
   end
 
-  def all_users
-    [admin_user, test_user(name: "User_one", id: "75fda9a1-786d-4ace-ad20-76afa4f39111"), test_user(name: "User_two"), test_user(name: "User_three")]
+  def set_user_as_team_admin(user = User.current)
+    allow(@keycloak_client_instance).to receive(:has_role?).with(user.id, :team_admin).and_return(true)
   end
 
-  def logout
-    allow(Keycloak::Client).to receive(:auth_server_url).and_call_original
-    allow(Keycloak::Client).to receive(:user_signed_in?).and_call_original
-    allow(Keycloak::Client).to receive(:get_userinfo).and_call_original
-    allow(Keycloak::Client).to receive(:has_role?).and_call_original
-    allow(User).to receive(:current).and_call_original
-    allow(NotifyMailer).to receive(:investigation_updated).and_call_original
-    allow(NotifyMailer).to receive(:investigation_created).and_call_original
-    reset_user_data
+  def set_user_as_not_team_admin(user = User.current)
+    allow(@keycloak_client_instance).to receive(:has_role?).with(user.id, :team_admin).and_return(false)
   end
 
   def assert_same_elements(expected, actual, msg = nil)
@@ -131,37 +137,24 @@ class ActiveSupport::TestCase
 
 private
 
+  def next_id
+    @id ||= 0
+    @id += 1
+  end
+
   def admin_user
-    User.new(id: SecureRandom.uuid, email: "admin@example.com", first_name: "Test", last_name: "Admin")
+    id = SecureRandom.uuid
+    allow(@keycloak_client_instance).to receive(:has_role?).with(id, :team_admin).and_return(false)
+    allow(@keycloak_client_instance).to receive(:has_role?).with(id, :mspsds_user).and_return(true)
+    allow(@keycloak_client_instance).to receive(:has_role?).with(id, :opss_user).and_return(true)
+    User.new(id: id, email: "admin@example.com", first_name: "Test", last_name: "Admin")
   end
 
   def test_user(name: "User_one", id: SecureRandom.uuid)
+    allow(@keycloak_client_instance).to receive(:has_role?).with(id, :team_admin).and_return(false)
+    allow(@keycloak_client_instance).to receive(:has_role?).with(id, :mspsds_user).and_return(true)
+    allow(@keycloak_client_instance).to receive(:has_role?).with(id, :opss_user).and_return(true)
     User.new(id: id, email: "#{name}@example.com", first_name: "Test", last_name: name)
-  end
-
-  def group_data
-    [
-      {
-        id: "13763657-d228-4209-a3de-523dcab13810",
-        name: "Group 1",
-        path: "/Group 1",
-        subGroups: []
-      }, {
-        id: "512c85e6-5a7f-4289-95e2-a78c0e40f05c",
-        name: "Organisations",
-        path: "/Organisations",
-        subGroups: organisations.map do |org|
-          result = org.attributes.merge(subGroups: [])
-          result = result.merge(subGroups: all_teams.map(&:attributes)) if org.name == "Office of Product Safety and Standards"
-          result
-        end
-      }, {
-        id: "10036801-2182-4c5b-92d9-b34b1e0a421b",
-        name: "Group 2",
-        path: "/Group 2",
-        subGroups: []
-      }
-    ].to_json
   end
 
   def organisations
@@ -176,6 +169,12 @@ private
     Organisation.new(id: "1a612aea-1d3d-47ee-8c3a-76b4448bb97b", name: "Office of Product Safety and Standards", path: "/Organisations/Organisation 2")
   end
 
+  def set_kc_user_group(user_id, group_id)
+    mock_user = @users.find { |u| u[:id] == user_id }
+    mock_user[:groups] ||= []
+    mock_user[:groups].push group_id
+  end
+
   def all_teams
     [
       Team.new(id: "aaaaeef8-1a33-4322-8b8c-fc7fa95a2e3b", name: "Team 1", path: "/Organisations/Office of Product Safety and Standards/Team 1", organisation_id: "1a612aea-1d3d-47ee-8c3a-76b4448bb97b"),
@@ -185,63 +184,8 @@ private
     ]
   end
 
-  def stub_user_credentials(user:, groups:, is_admin: false, is_opss: true, is_mspsds: true)
-    allow(Keycloak::Client).to receive(:user_signed_in?).and_return(true)
-    allow(Keycloak::Client).to receive(:get_userinfo).and_return(format_user_for_get_userinfo(user, groups))
-    allow(Keycloak::Client).to receive(:has_role?).with(:admin).and_return(is_admin)
-    allow(Keycloak::Client).to receive(:has_role?).with(:opss_user).and_return(is_opss)
-    allow(Keycloak::Client).to receive(:has_role?).with(:mspsds_user).and_return(is_mspsds)
-
-    allow(User).to receive(:current).and_return(user)
-  end
-
-  def format_user_for_get_userinfo(user, groups)
-    { sub: user[:id], email: user[:email], groups: groups, given_name: user[:first_name], family_name: user[:last_name] }.to_json
-  end
-
-  def stub_client_config
-    allow(Keycloak::Client).to receive(:auth_server_url).and_return("localhost")
-  end
-
-  def stub_user_data(users:)
-    allow(Keycloak::Internal).to receive(:get_users).and_return(format_user_for_get_users(users))
-    User.all
-  end
-
-  def stub_user_group_data(user_groups:, users: [])
-    Shared::Web::KeycloakClient.instance # Instantiate the class to create the get_groups method before stubbing it
-    allow(Keycloak::Internal).to receive(:get_group) do |group_id|
-      result = {}
-      all_teams.each do|team|
-        result = { "attributes": { "teamRecipientEmail": [team.team_recipient_email] } } if group_id == team.id
-      end
-      result.to_json
-    end
-    allow(Keycloak::Internal).to receive(:get_groups).and_return(group_data)
-    allow(Keycloak::Internal).to receive(:all_groups).and_return(JSON.parse(group_data))
-    allow(Keycloak::Internal).to receive(:all_organisations).and_call_original
-    allow(Keycloak::Internal).to receive(:all_teams).and_return(all_teams.map(&:attributes))
-    allow(Keycloak::Internal).to receive(:all_users).and_return(users)
-    allow(Keycloak::Internal).to receive(:get_user_groups).and_return(user_groups)
-    allow(Keycloak::Internal).to receive(:all_team_users).and_call_original
-
-    load_keycloak_data
-  end
-
-  def load_keycloak_data
-    Organisation.all
-    Team.all
-    TeamUser.all
-  end
-
   def format_user_for_get_users(users)
     users.map { |user| { id: user[:id], email: user[:email], firstName: user[:first_name], lastName: user[:last_name] } }.to_json
   end
 
-  def reset_user_data
-    allow(Keycloak::Internal).to receive(:get_groups).and_call_original
-    allow(Keycloak::Internal).to receive(:get_users).and_call_original
-    allow(Keycloak::Internal).to receive(:get_user_groups).and_call_original
-    Rails.cache.delete(:keycloak_users)
-  end
 end

--- a/mspsds-web/test/test_helper.rb
+++ b/mspsds-web/test/test_helper.rb
@@ -20,7 +20,7 @@ class ActiveSupport::TestCase
 
   def initialize *args
     @keycloak_client_instance = Shared::Web::KeycloakClient.instance
-    super *args
+    super(*args)
   end
 
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
@@ -41,7 +41,6 @@ class ActiveSupport::TestCase
   def setup
     self.class.import_into_elasticsearch
   end
-
 
   # On top of mocking out external services, this method also sets the user to an initial,
   # sensible value, but it should only be run once per test.
@@ -187,5 +186,4 @@ private
   def format_user_for_get_users(users)
     users.map { |user| { id: user[:id], email: user[:email], firstName: user[:first_name], lastName: user[:last_name] } }.to_json
   end
-
 end

--- a/mspsds-web/test/test_helper.rb
+++ b/mspsds-web/test/test_helper.rb
@@ -47,19 +47,19 @@ class ActiveSupport::TestCase
   # To change currently logged in user afterwards call `sign_in_as(...)`
   def mock_out_keycloak_and_notify(user_name: "User_one", team_admin: false)
     @users = [admin_user,
-              test_user(name: "User_one", id: "75fda9a1-786d-4ace-ad20-76afa4f39111"),
+              test_user(name: "User_one"),
               test_user(name: "User_two"),
               test_user(name: "User_three")].map(&:attributes)
     @organisations = organisations.map(&:attributes)
     @teams = all_teams.map(&:attributes)
     @team_users = [
-        { id: next_id, user_id: @users[1][:id], team_id: all_teams[0].id },
-        { id: next_id, user_id: @users[1][:id], team_id: all_teams[1].id },
-        { id: next_id, user_id: @users[0][:id], team_id: all_teams[0].id },
-        { id: next_id, user_id: @users[2][:id], team_id: all_teams[1].id },
-        { id: next_id, user_id: @users[3][:id], team_id: all_teams[2].id },
-        { id: next_id, user_id: @users[3][:id], team_id: all_teams[3].id }
-    ]
+        { user_id: @users[1][:id], team_id: all_teams[0].id },
+        { user_id: @users[1][:id], team_id: all_teams[1].id },
+        { user_id: @users[0][:id], team_id: all_teams[0].id },
+        { user_id: @users[2][:id], team_id: all_teams[1].id },
+        { user_id: @users[3][:id], team_id: all_teams[2].id },
+        { user_id: @users[3][:id], team_id: all_teams[3].id }
+    ].each_with_index.map { |team_user, id| team_user.merge(id: id) }
 
     allow(@keycloak_client_instance).to receive(:all_organisations) { @organisations }
     allow(@keycloak_client_instance).to receive(:all_teams) { @teams }
@@ -135,11 +135,6 @@ class ActiveSupport::TestCase
   end
 
 private
-
-  def next_id
-    @id ||= 0
-    @id += 1
-  end
 
   def admin_user
     id = SecureRandom.uuid

--- a/shared-web/app/clients/shared/web/keycloak_client.rb
+++ b/shared-web/app/clients/shared/web/keycloak_client.rb
@@ -103,14 +103,6 @@ module Shared
         JSON.parse(response)["attributes"] || {}
       end
 
-      def all_groups
-        response = Rails.cache.fetch(:keycloak_groups, expires_in: 5.minutes) do
-          Keycloak::Internal.get_groups
-        end
-
-        JSON.parse(response)
-      end
-
       def registration_url(redirect_uri)
         params = URI.encode_www_form(client_id: Keycloak::Client.client_id, response_type: "code", redirect_uri: redirect_uri)
         Keycloak::Client.auth_server_url + "/realms/#{Keycloak::Client.realm}/protocol/openid-connect/registrations?#{params}"
@@ -164,6 +156,15 @@ module Shared
 
         JSON.parse(response).collect { |user| [user["id"], user["groups"]] }.to_h
       end
+
+      def all_groups
+        response = Rails.cache.fetch(:keycloak_groups, expires_in: 5.minutes) do
+          Keycloak::Internal.get_groups
+        end
+
+        JSON.parse(response)
+      end
+
     end
   end
 end

--- a/shared-web/app/clients/shared/web/keycloak_client.rb
+++ b/shared-web/app/clients/shared/web/keycloak_client.rb
@@ -164,7 +164,6 @@ module Shared
 
         JSON.parse(response)
       end
-
     end
   end
 end


### PR DESCRIPTION
## Description
KeycloakClient is a much better boundary at which to set our mocks,
rather than reverse-engineering the internals of the gem. It gives us
a clear idea of how far which test should care re: set-up and it makes
us less reliant on the particular implementation

I'd like to push this in separately to the rest of MSPSDS-1047 to get early feedback on it and make sure it doesn't get out of sync too much with everyone else's tickets :)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [x] CHANGELOG updated if change is worth telling users about.