### PR TITLE
COSBETA-176: Index document in the after_save hook

### DIFF
--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -24,7 +24,6 @@ class Notification < ApplicationRecord
 
   before_save :add_product_name, if: :will_save_change_to_product_name?
   before_save :add_import_country, if: :will_save_change_to_import_country?
-  after_save :update_elasticsearch_index
 
   def self.duplicate_notification_message
     "Notification duplicated"
@@ -85,7 +84,8 @@ class Notification < ApplicationRecord
     end
 
     event :submit_notification do
-      transitions from: :draft_complete, to: :notification_complete, guard: :images_are_present_and_safe?
+      transitions from: :draft_complete, to: :notification_complete, guard: :images_are_present_and_safe?,
+                  after: Proc.new { update_elasticsearch_index }
     end
   end
   # rubocop:enable Metrics/BlockLength

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -89,6 +89,12 @@ class Notification < ApplicationRecord
   end
   # rubocop:enable Metrics/BlockLength
 
+  after_save do
+    if saved_changes.key?(:status) && status == "notification_complete"
+     __elasticsearch__.index_document
+    end
+  end
+
   def reference_number_for_display
     "UKCP-%08d" % reference_number
   end


### PR DESCRIPTION
Add elasticsearch indexing when a notification is updated from non-complete to complete. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.