### PR TITLE
MSPSDS-6: Remove .js-enabled if JavaScript isn't successfully loaded

### DIFF
--- a/cosmetics-web/app/views/layouts/_footer.html.slim
+++ b/cosmetics-web/app/views/layouts/_footer.html.slim
@@ -14,4 +14,5 @@ footer.govuk-footer[role="contentinfo"]
           | © Crown copyright
 
 javascript:
+  if (typeof window.GOVUKFrontend === 'undefined') document.body.className = document.body.className.replace('js-enabled', '')
   window.GOVUKFrontend.initAll()

--- a/mspsds-web/app/views/layouts/application.html.slim
+++ b/mspsds-web/app/views/layouts/application.html.slim
@@ -106,4 +106,5 @@ html.govuk-template.app-html-class[lang="en"]
               | © Crown copyright
 
     javascript:
+      if (typeof window.GOVUKFrontend === 'undefined') document.body.className = document.body.className.replace('js-enabled', '')
       window.GOVUKFrontend.initAll()


### PR DESCRIPTION
## Description
If the JS doesn't load for some reason (e.g. an IE specific issue...), we should remove the `.js-enabled` class so that the design system's progressive enhancement stuff can still function (e.g. with tabs).

This is based on https://github.com/alphagov/govuk_template/blob/master/source/views/layouts/govuk_template.html.erb#L113. More discussion at https://github.com/alphagov/govuk-frontend/issues/999

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [x] CHANGELOG updated if change is worth telling users about.
