### PR TITLE
MSPSDS-786: Add server metric exporting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "keycloak/providers/sms-authenticator"]
 	path = keycloak/providers/sms-authenticator
 	url = https://github.com/UKGovernmentBEIS/keycloak-sms-authenticator-sns.git
+[submodule "infrastructure/paas-metric-exporter"]
+	path = infrastructure/paas-metric-exporter
+	url = https://github.com/alphagov/paas-metric-exporter.git

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -47,7 +47,33 @@ See [the root README](../README.md#amazon-web-services) for more details about s
 
 ### Metrics
 
-TODO MSPSDS-786: Probably using https://github.com/alphagov/paas-metric-exporter as a base
+Our metrics are sent to an ELK stack and S3 using [the paas-metric-exporter app](./paas-metric-exporter).
+
+
+#### Deployment
+
+Create or target a common space using `cf create-space common` or `cf target -o beis-mspsds -s common`.
+
+Deploy the app by running `cf push --no-start` from the `paas-metric-exporter` folder.
+Once the app has been created, define the following environment variables:
+
+Set the metrics to be logged to stdout using:
+    
+    cf set-env metric-exporter DEBUG true
+
+Tell the app to connect to the London PaaS API
+
+    cf set-env metric-exporter API_ENDPOINT https://api.london.cloud.service.gov.uk
+
+Provide some credentials (these should be for a user with only the "Space auditor" permission on the spaces to be monitored) to connect to the API with:
+
+    cf set-env metric-exporter USERNAME XXX
+    cf set-env metric-exporter PASSWORD XXX
+
+Follow the instructions above to create and bind the `opss-log-drain` to the `metric-exporter` app.
+
+Finally, start the app using `cf start metric-exporter`.
+Running `cf logs metric-exporter` should show metrics from all of the spaces that the user has the "Space auditor" permission for.
 
 
 ### Uptime check

--- a/infrastructure/fluentd/plugins/out_logit.rb
+++ b/infrastructure/fluentd/plugins/out_logit.rb
@@ -62,7 +62,7 @@ module Fluent::Plugin
 
     def prepare_data_to_send(_tag, _time, record)
       # Just forward on the message
-      "#{record['message']}\n"
+      record['message']
     end
 
     def connect

--- a/infrastructure/logstash-filters.conf
+++ b/infrastructure/logstash-filters.conf
@@ -21,8 +21,6 @@ filter {
         tag_on_failure => ["_sysloghostdissectfailure"]
     }
 
-    # TODO MSPSDS-786: Parse metric-exporter logs explicitly
-
     # Cloud Foundry gorouter logs
     if [syslog_proc] =~ "RTR" {
         mutate { replace => { "type" => "gorouter" } }
@@ -43,12 +41,42 @@ filter {
         }
     }
 
-    # Application logs
-    if [syslog_proc] =~ "APP" {
-        json {
-            source => "syslog_msg"
-            add_tag => ["app"]
+    # paas-metric-exporter logs
+    if [syslog_proc] =~ "APP" and [cf][app] =~ "metric-exporter" {
+        mutate {
+            replace => { "type" => "metric" }
+            add_tag => ["metric"]
         }
+
+        if [syslog_msg] =~ "^gauge" {
+            dissect {
+                mapping => { "syslog_msg" => "%{[metric][type]} mycf.%{[cf][space]}.%{[cf][app]}.%{[cf][app_instance]}.%{[metric][name]} %{[metric][value]}" }
+                convert_datatype => {
+                    "[cf][app_instance]" => "int"
+                    "[metric][value]" => "int"
+                }
+                tag_on_failure => ["_gaugemetricparsefailure"]
+            }
+        } else if [syslog_msg] =~ "^timing" or [syslog_msg] =~ "^incr" {
+            dissect {
+                mapping => { "syslog_msg" => "%{[metric][type]} mycf.%{[cf][space]}.%{[cf][app]}.%{[cf][app_instance]}.%{[metric][name]}.%{[metric][status_range]} %{[metric][value]}" }
+                convert_datatype => {
+                    "[cf][app_instance]" => "int"
+                    "[metric][value]" => "int"
+                }
+                tag_on_failure => ["_timingmetricparsefailure"]
+            }
+        } else if [syslog_msg] =~ "^app" {
+            dissect {
+                mapping => { "syslog_msg" => "%{[metric][type]} %{[metric][guid]} %{[metric][name]}" }
+                tag_on_failure => ["_appmetricparsefailure"]
+            }
+        } else {
+            mutate { add_tag => ["_unknownmetricparsefailure"] }
+        }
+    } else if [syslog_proc] =~ "APP" {
+        # Other application logs
+        mutate { add_tag => ["app"] }
     }
 
     # User agent parsing


### PR DESCRIPTION
## Description
`metric-exporter` captures all metrics from spaces that it has the "Space auditor" role for (which is currently int, staging, prod and research) which are then sent to fluentd and onto Logit and S3. I'll add some dashboards soon!

## Checklist:
- [x] Automated checks are passing locally.
- [x] CHANGELOG updated if change is worth telling users about.
