### PR TITLE
COSBETA-199 Remove companies house number from Responsible Person model

### DIFF
--- a/cosmetics-web/app/controllers/responsible_persons/account_wizard_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/account_wizard_controller.rb
@@ -87,7 +87,6 @@ private
     params.fetch(:responsible_person, {}).permit(
       :account_type,
       :name,
-      :companies_house_number,
       :email_address,
       :phone_number,
       :address_line_1,

--- a/cosmetics-web/app/models/responsible_person.rb
+++ b/cosmetics-web/app/models/responsible_person.rb
@@ -11,7 +11,6 @@ class ResponsiblePerson < ApplicationRecord
   validates :account_type, presence: true
   validates :email_address, uniqueness: true
 
-  validates :companies_house_number, presence: true, uniqueness: true, on: %i[enter_details create], if: -> { business? }
   validates :name, presence: true, on: %i[enter_details create]
   validates :email_address, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }, on: %i[enter_details create]
   validates :phone_number, presence: true, on: %i[enter_details create]

--- a/cosmetics-web/app/views/responsible_persons/account_wizard/enter_details.slim
+++ b/cosmetics-web/app/views/responsible_persons/account_wizard/enter_details.slim
@@ -14,16 +14,13 @@
 
     - if @responsible_person.business?
       p[class="govuk-!-margin-bottom-9"]
-        | Find your company information, including registration number on
+        | Find your company information on
         br
         = link_to "Companies House (opens in a new tab)", "https://beta.companieshouse.gov.uk",
                 class: "govuk-link", target: "_blank", rel: "noopener"
         | .
 
     = form_with model: @responsible_person, url: wizard_path, method: :put do |form|
-      - if @responsible_person.business?
-        = render "form_input", form: form, field: :companies_house_number, label: "Companies House registration number"
-
       = render "form_input", form: form, field: :name, label: name_label
       = render "form_input", form: form, field: :email_address, type: :email_field, label: "Email address"
       = render "form_input", form: form, field: :phone_number, type: :telephone_field, label: "Phone number",

--- a/cosmetics-web/config/locales/en.yml
+++ b/cosmetics-web/config/locales/en.yml
@@ -23,7 +23,6 @@ en:
   activerecord:
     attributes:
       responsible_person:
-        companies_house_number: "Companies House registration number"
         address_line_1: "Building and street"
         city: "Town or city"
         postal_code: "Postcode"

--- a/cosmetics-web/db/migrate/20190318114749_remove_business_number_from_responsible_person.rb
+++ b/cosmetics-web/db/migrate/20190318114749_remove_business_number_from_responsible_person.rb
@@ -1,0 +1,17 @@
+class RemoveBusinessNumberFromResponsiblePerson < ActiveRecord::Migration[5.2]
+  def change
+    safety_assured do
+      reversible do |dir|
+        change_table :responsible_persons do |t|
+          dir.up do
+            t.remove :companies_house_number
+          end
+
+          dir.down do
+            t.string :companies_house_number
+          end
+        end
+      end
+    end
+  end
+end

--- a/cosmetics-web/db/schema.rb
+++ b/cosmetics-web/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_13_115313) do
+ActiveRecord::Schema.define(version: 2019_03_18_114749) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -166,7 +166,6 @@ ActiveRecord::Schema.define(version: 2019_03_13_115313) do
   create_table "responsible_persons", force: :cascade do |t|
     t.string "account_type"
     t.string "name"
-    t.string "companies_house_number"
     t.string "email_address"
     t.string "phone_number"
     t.string "address_line_1"

--- a/cosmetics-web/spec/factories/responsible_person.rb
+++ b/cosmetics-web/spec/factories/responsible_person.rb
@@ -11,7 +11,6 @@ FactoryBot.define do
 
     factory :business_responsible_person do
       account_type { :business }
-      companies_house_number { "12345678" }
     end
 
     factory :responsible_person_with_user do

--- a/cosmetics-web/spec/models/responsible_person_spec.rb
+++ b/cosmetics-web/spec/models/responsible_person_spec.rb
@@ -70,28 +70,5 @@ RSpec.describe ResponsiblePerson, type: :model do
       expect(responsible_person.save).to be false
       expect(responsible_person.errors[:email_address]).to include("Email address is invalid")
     end
-
-    it "succeeds if a Companies House number is not specified for individual account type" do
-      responsible_person.account_type = :individual
-      responsible_person.companies_house_number = nil
-
-      expect(responsible_person.save).to be true
-    end
-
-    it "fails if a Companies House number is not specified for business account type" do
-      responsible_person.account_type = :business
-      responsible_person.companies_house_number = nil
-
-      expect(responsible_person.save).to be false
-      expect(responsible_person.errors[:companies_house_number]).to include("Companies House registration number can't be blank")
-    end
-
-    it "fails if the Companies House number is not unique for business account type" do
-      create(:business_responsible_person, companies_house_number: "12345678")
-      responsible_person = build(:business_responsible_person, companies_house_number: "12345678")
-
-      expect(responsible_person.save).to be false
-      expect(responsible_person.errors[:companies_house_number]).to include("has already been taken")
-    end
   end
 end

--- a/cosmetics-web/spec/system/create_responsible_person_spec.rb
+++ b/cosmetics-web/spec/system/create_responsible_person_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe "Create a responsible person", type: :system do
 
     assert_text "UK responsible person details"
 
-    fill_in "Companies House registration number", with: responsible_person.companies_house_number
     fill_in "Registered business name", with: responsible_person.name
     fill_in "Email address", with: responsible_person.email_address
     fill_in "Phone number", with: responsible_person.phone_number
@@ -49,27 +48,6 @@ RSpec.describe "Create a responsible person", type: :system do
     click_on "Continue"
 
     assert_current_path(/responsible_persons\/\d+\/verify/)
-  end
-
-  it "requires a Companies House registration number for a business account" do
-    responsible_person = build(:business_responsible_person)
-
-    create_new_responsible_person
-    select_business_account_type
-
-    assert_text "UK responsible person details"
-
-    fill_in "Registered business name", with: responsible_person.name
-    fill_in "Email address", with: responsible_person.email_address
-    fill_in "Phone number", with: responsible_person.phone_number
-    fill_in "Building and street", with: responsible_person.address_line_1
-    fill_in "Town or city", with: responsible_person.city
-    fill_in "County", with: responsible_person.county
-    fill_in "Postcode", with: responsible_person.postal_code
-    click_on "Continue"
-
-    assert_current_path account_path(:enter_details)
-    assert_text "Companies House registration number can't be blank"
   end
 
   it "requires an account type to be selected" do


### PR DESCRIPTION
Removes the companies house number from the RP model, and removes all tests/text that references it

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
