### PR TITLE
MSPSDS-1107: Update document back links to go to case page

### DIFF
--- a/mspsds-web/app/views/documents/edit.html.slim
+++ b/mspsds-web/app/views/documents/edit.html.slim
@@ -1,5 +1,6 @@
 - content_for :page_title, "Edit document"
 - content_for :after_header do
-  = link_to "Back", associated_documents_path(@parent), class: "govuk-back-link"
+  = link_to "Back", polymorphic_path(@parent), class: "govuk-back-link"
+
 = render "metadata_form", document: @file, edit: true, target_url: associated_document_path(@parent, @file) do
   = render "page_heading", title: "Edit document details"

--- a/mspsds-web/app/views/documents/remove.html.slim
+++ b/mspsds-web/app/views/documents/remove.html.slim
@@ -1,6 +1,7 @@
 - content_for :page_title, "Remove attachment"
 - content_for :after_header do
-  = link_to "Back", associated_documents_path(@parent), class: "govuk-back-link"
+  = link_to "Back", polymorphic_path(@parent), class: "govuk-back-link"
+
 = render "page_heading", title: "Remove attachment"
 
 .govuk-grid-row


### PR DESCRIPTION
## Description
The route for `associated_documents_path` didn't exist, so I've updated it to take them to `/products` or `/cases` instead.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [x] CHANGELOG updated if change is worth telling users about.