### PR TITLE
MSPSDS-1116 Filter out users without mspsds access from users collection

### DIFF
--- a/mspsds-web/app/controllers/teams_controller.rb
+++ b/mspsds-web/app/controllers/teams_controller.rb
@@ -56,7 +56,7 @@ private
   end
 
   def invite_user(user)
-    @team.add_user user
+    @team.add_user user.id
     email = NotifyMailer.user_added_to_team user.email,
                                             name: user.full_name,
                                             team_page_url: team_url(@team),

--- a/mspsds-web/app/models/team.rb
+++ b/mspsds-web/app/models/team.rb
@@ -19,8 +19,8 @@ class Team < ActiveHash::Base
     team_users.map(&:user)
   end
 
-  def add_user(user)
-    Shared::Web::KeycloakClient.instance.add_user_to_team user.id, id
+  def add_user(user_id)
+    Shared::Web::KeycloakClient.instance.add_user_to_team user_id, id
     # Trigger reload of users and relations from KC
     User.all(force: true)
   end

--- a/mspsds-web/test/controllers/contacts_controller_test.rb
+++ b/mspsds-web/test/controllers/contacts_controller_test.rb
@@ -6,6 +6,10 @@ class ContactsControllerTest < ActionDispatch::IntegrationTest
     @contact = contacts(:one)
   end
 
+  teardown do
+    reset_keycloak_and_notify_mocks
+  end
+
   test "should get new" do
     get new_business_contact_url(@contact.business)
     assert_response :success

--- a/mspsds-web/test/controllers/homepage_controller_test.rb
+++ b/mspsds-web/test/controllers/homepage_controller_test.rb
@@ -10,13 +10,13 @@ class HomepageControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "displays introduction for non_opss users who have not viewed introduction before" do
-    set_user_as_non_opss(User.current)
+    mock_user_as_non_opss(User.current)
     get "/"
     assert_redirected_to introduction_overview_path
   end
 
   test "displays homepage for non_opss users who have viewed introduction before" do
-    set_user_as_non_opss(User.current)
+    mock_user_as_non_opss(User.current)
     allow(User.current).to receive(:has_viewed_introduction).and_return true
 
     get '/'

--- a/mspsds-web/test/controllers/investigations_controller_test.rb
+++ b/mspsds-web/test/controllers/investigations_controller_test.rb
@@ -6,7 +6,7 @@ class InvestigationsControllerTest < ActionDispatch::IntegrationTest
 
     @assignee = User.find_by(last_name: "User_one")
     @non_opss_user = User.find_by(last_name: "User_two")
-    set_user_as_non_opss(@non_opss_user)
+    mock_user_as_non_opss(@non_opss_user)
 
     @investigation_one = investigations(:one)
     @investigation_one.created_at = Time.zone.parse('2014-07-11 21:00')

--- a/mspsds-web/test/controllers/team_test.rb
+++ b/mspsds-web/test/controllers/team_test.rb
@@ -86,7 +86,7 @@ class TeamTest < ActionDispatch::IntegrationTest
     get investigations_path, params: {
       assigned_to_me: "unchecked",
       assigned_to_someone_else: "checked",
-      assigned_to_someone_else_id: all_teams[2].id,
+      assigned_to_someone_else_id: Team.find_by(name: "Team 3").id,
       assigned_to_team_0: @user_one.teams[0].id,
       assigned_to_team_1: nil
     }
@@ -131,7 +131,7 @@ class TeamTest < ActionDispatch::IntegrationTest
     get investigations_path, params: {
       assigned_to_me: "unchecked",
       assigned_to_someone_else: "checked",
-      assigned_to_someone_else_id: all_teams[2].id,
+      assigned_to_someone_else_id: Team.find_by(name: "Team 3").id,
       assigned_to_team_0: nil,
       assigned_to_team_1: nil
     }
@@ -158,14 +158,16 @@ class TeamTest < ActionDispatch::IntegrationTest
     @investigation_user_three = Investigation.find_by(description: "Investigation for search by correspondence")
     assert_equal @investigation_user_three.assignee, @user_three
 
+    team1 = Team.find_by(name: "Team 1")
     investigation = Investigation.find_by(description: "Investigation with no product")
-    investigation.update(assignee: all_teams[0])
+    investigation.update(assignee: team1)
     @investigation_team_one = Investigation.find_by(description: "Investigation with no product")
-    assert_equal @investigation_team_one.assignee, all_teams[0]
+    assert_equal @investigation_team_one.assignee, team1
 
+    team2 = Team.find_by(name: "Team 3")
     investigation = Investigation.find_by(description: "Investigation for search by product")
-    investigation.update(assignee: all_teams[2])
+    investigation.update(assignee: team2)
     @investigation_team_three = Investigation.find_by(description: "Investigation for search by product")
-    assert_equal @investigation_team_three.assignee, all_teams[2]
+    assert_equal @investigation_team_three.assignee, team2
   end
 end

--- a/mspsds-web/test/controllers/teams_controller_test.rb
+++ b/mspsds-web/test/controllers/teams_controller_test.rb
@@ -64,8 +64,7 @@ class TeamsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "Inviting existing user from different org doesn't add and shows error" do
-    non_opss_user = Organisation.all.find { |o| o != User.current.organisation }.users
-    email_address = non_opss_user.first.email
+    email_address = Organisation.find_by(name: "Organisation 1").users.first.email
     assert_difference "@my_team.users.count" => 0, "User.count" => 0 do
       put invite_to_team_url(@my_team), params: { new_user: { email_address: email_address } }
       assert_response :bad_request

--- a/mspsds-web/test/models/corrective_action_test.rb
+++ b/mspsds-web/test/models/corrective_action_test.rb
@@ -8,6 +8,10 @@ class CorrectiveActionTest < ActiveSupport::TestCase
     mock_out_keycloak_and_notify
   end
 
+  teardown do
+    reset_keycloak_and_notify_mocks
+  end
+
   test "requires an associated investigation, business and product" do
     corrective_action = create_valid_corrective_action
     corrective_action.update(investigation: nil, business: nil, product: nil)

--- a/mspsds-web/test/models/investigation_test.rb
+++ b/mspsds-web/test/models/investigation_test.rb
@@ -184,18 +184,18 @@ class InvestigationTest < ActiveSupport::TestCase
   test "visible to creator organisation" do
     create_new_private_case
     creator = User.find_by(last_name: "User_one")
-    set_user_as_non_opss(creator)
+    mock_user_as_non_opss(creator)
     user = User.find_by(last_name: "User_two")
-    set_user_as_non_opss(user)
+    mock_user_as_non_opss(user)
     assert_equal(policy(@new_investigation).show?(user: user), true)
   end
 
   test "visible to assignee organisation" do
     create_new_private_case
     assignee = User.find_by(last_name: "User_two")
-    set_user_as_opss(assignee)
+    mock_user_as_opss(assignee)
     user = User.find_by(last_name: "User_three")
-    set_user_as_opss(user)
+    mock_user_as_opss(user)
     @new_investigation.assignee = assignee
     assert(policy(@new_investigation).show?(user: user))
   end
@@ -203,7 +203,7 @@ class InvestigationTest < ActiveSupport::TestCase
   test "not visible to no-source, no-assignee organisation" do
     create_new_private_case
     sign_in_as User.find_by(last_name: "User_two")
-    set_user_as_non_opss(User.current)
+    mock_user_as_non_opss(User.current)
     assert_not(policy(@new_investigation).show?(user: User.current))
   end
 
@@ -233,13 +233,13 @@ class InvestigationTest < ActiveSupport::TestCase
 
   test "people out of currently assigned team should not be able to re-assign case" do
     investigation = Investigation::Allegation.create(description: "new_investigation_description")
-    investigation.assignee = all_teams[0]
+    investigation.assignee = Team.find_by(name: "Team 1")
     assert_not policy(investigation).assign?(user: User.find_by(last_name: "User_three"))
   end
 
   test "people in currently assigned team should be able to re-assign case" do
     investigation = Investigation::Allegation.create(description: "new_investigation_description")
-    investigation.assignee = all_teams[0]
+    investigation.assignee = Team.find_by(name: "Team 1")
     assert policy(investigation).assign?(user: User.find_by(last_name: "User_four"))
   end
 

--- a/mspsds-web/test/models/user_test.rb
+++ b/mspsds-web/test/models/user_test.rb
@@ -5,8 +5,8 @@ class UserTest < ActiveSupport::TestCase
     mock_out_keycloak_and_notify
     @user = User.find_by(last_name: "User_one")
     @user_four = User.find_by(last_name: "User_four")
-    set_user_as_non_opss(@user)
-    set_user_as_opss(@user_four)
+    mock_user_as_non_opss(@user)
+    mock_user_as_opss(@user_four)
   end
 
   teardown do
@@ -42,5 +42,10 @@ class UserTest < ActiveSupport::TestCase
 
     assert_includes options, @user
     assert_not_includes options, @user_four
+  end
+
+  test "don't load non-mspsds users" do
+    User.all
+    assert_not User.find_by(last_name: "Non_mspsds_user")
   end
 end

--- a/mspsds-web/test/system/create_ts_investigation_test.rb
+++ b/mspsds-web/test/system/create_ts_investigation_test.rb
@@ -7,7 +7,7 @@ class CreateTsInvestigationTest < ApplicationSystemTestCase
 
   setup do
     mock_out_keycloak_and_notify
-    set_user_as_non_opss(User.current)
+    mock_user_as_non_opss(User.current)
 
     @product = products(:one)
     @investigation = investigations(:one)

--- a/mspsds-web/test/system/introduction_test.rb
+++ b/mspsds-web/test/system/introduction_test.rb
@@ -3,7 +3,7 @@ require "application_system_test_case"
 class IntroductionTest < ApplicationSystemTestCase
   setup do
     mock_out_keycloak_and_notify
-    set_user_as_non_opss User.current
+    mock_user_as_non_opss User.current
 
     visit '/'
   end
@@ -47,7 +47,7 @@ class IntroductionTest < ApplicationSystemTestCase
   end
 
   test "does not show introduction to opss users" do
-    set_user_as_opss User.current
+    mock_user_as_opss User.current
 
     visit '/'
 

--- a/shared-web/app/clients/shared/web/keycloak_client.rb
+++ b/shared-web/app/clients/shared/web/keycloak_client.rb
@@ -181,6 +181,10 @@ module Shared
         @internal.create_user email: email, username: email, enabled: true
       end
 
+      def get_user(email)
+        @internal.get_user_info(email).first.symbolize_keys
+      end
+
       def send_required_actions_welcome_email(user_id, redirect_uri)
         required_actions = %w(sms_auth_check_mobile UPDATE_PASSWORD UPDATE_PROFILE VERIFY_EMAIL)
         @internal.execute_actions_email user_id, required_actions, "mspsds-app", redirect_uri


### PR DESCRIPTION
## Description
This required some changes to the tests set up, which was still quite
circular: the tests set up some KC mocking, then loaded the collections,
the performed further set-up. Now, I've removed all collection
references from the mocking layer, making the responsibilities much
clearer.
