### PR TITLE
COSBETA-165 Fix requirements for pre and post brexit notifications

### DIFF
--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -4,6 +4,8 @@ class Notification < ApplicationRecord
   include AASM
   include Shared::Web::CountriesHelper
 
+  EU_EXIT_DATETIME = DateTime.parse("29-03-2019T23:00:00").in_time_zone
+
   belongs_to :responsible_person
   has_many :components, dependent: :destroy
   has_many :image_uploads, dependent: :destroy
@@ -137,11 +139,11 @@ class Notification < ApplicationRecord
   end
 
   def notified_post_eu_exit?
-    !was_notified_before_eu_exit? || (cpnp_notification_date.present? && (cpnp_notification_date > Date.parse("29-03-2019")))
+    !notified_pre_eu_exit?
   end
 
   def notified_pre_eu_exit?
-    !notified_post_eu_exit?
+    was_notified_before_eu_exit? || (cpnp_notification_date.present? && (cpnp_notification_date < EU_EXIT_DATETIME))
   end
 
 private

--- a/cosmetics-web/app/models/notification.rb
+++ b/cosmetics-web/app/models/notification.rb
@@ -87,7 +87,7 @@ class Notification < ApplicationRecord
       transitions from: :draft_complete, to: :notification_complete,
                   after: Proc.new { __elasticsearch__.index_document } do
         guard do
-          cpnp_reference.present? || images_are_present_and_safe?
+          notified_pre_eu_exit? || images_are_present_and_safe?
         end
       end
     end
@@ -134,6 +134,14 @@ class Notification < ApplicationRecord
 
   def is_multicomponent?
     components.length > 1
+  end
+
+  def notified_post_eu_exit?
+    !was_notified_before_eu_exit? || (cpnp_notification_date.present? && (cpnp_notification_date > Date.parse("29-03-2019")))
+  end
+
+  def notified_pre_eu_exit?
+    !notified_post_eu_exit?
   end
 
 private

--- a/cosmetics-web/app/views/notifications/_component_details.html.slim
+++ b/cosmetics-web/app/views/notifications/_component_details.html.slim
@@ -1,26 +1,27 @@
 /TODO: if post Brexit?
-tr.govuk-table__row
-  th.govuk-table__header[scope="row"]
-    | CMR
-  td.govuk-table__cell
-    = render "none_or_bullet_list", entities_list: component.cmrs.map(&:display_name)
+- if component.notification.notified_post_eu_exit?
+  tr.govuk-table__row
+    th.govuk-table__header[scope="row"]
+      | CMR
+    td.govuk-table__cell
+      = render "none_or_bullet_list", entities_list: component.cmrs.map(&:display_name)
 
-tr.govuk-table__row
-  th.govuk-table__header[scope="row"]
-    | Nanomaterials
-  td.govuk-table__cell
-    = render "none_or_bullet_list", entities_list: component.nano_material&.nano_elements&.map(&:display_name)
-- if component.nano_material&.nano_elements.present?
   tr.govuk-table__row
     th.govuk-table__header[scope="row"]
-      | Application instruction
+      | Nanomaterials
     td.govuk-table__cell
-      = component.nano_material.exposure_route
-  tr.govuk-table__row
-    th.govuk-table__header[scope="row"]
-      | Exposure condition
-    td.govuk-table__cell
-      = component.nano_material.exposure_condition
+      = render "none_or_bullet_list", entities_list: component.nano_material&.nano_elements&.map(&:display_name)
+  - if component.nano_material&.nano_elements.present?
+    tr.govuk-table__row
+      th.govuk-table__header[scope="row"]
+        | Application instruction
+      td.govuk-table__cell
+        = component.nano_material.exposure_route
+    tr.govuk-table__row
+      th.govuk-table__header[scope="row"]
+        | Exposure condition
+      td.govuk-table__cell
+        = component.nano_material.exposure_condition
 
 tr.govuk-table__row
   th.govuk-table__header[scope="row"]

--- a/cosmetics-web/app/views/notifications/_component_details.html.slim
+++ b/cosmetics-web/app/views/notifications/_component_details.html.slim
@@ -1,4 +1,3 @@
-/TODO: if post Brexit?
 - if component.notification.notified_post_eu_exit?
   tr.govuk-table__row
     th.govuk-table__header[scope="row"]


### PR DESCRIPTION
"As decided in the kick-off session (COSBETA‌-120), the CMR and nanomaterial properties should not be shown on the edit/show pages if the product was first notified on CPNP **prior** to Brexit date.

Product images are required before a product can be registered if it was first notified on CPNP **after** Brexit date."

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
