### PR TITLE
COSBETA-169: Add error highlight when uploading formulation fails

### DIFF
--- a/cosmetics-web/app/controllers/formulation_upload_controller.rb
+++ b/cosmetics-web/app/controllers/formulation_upload_controller.rb
@@ -12,16 +12,20 @@ class FormulationUploadController < ApplicationController
         redirect_to upload_formulation_responsible_person_notification_path(@component.notification.responsible_person, @component.notification)
       else
         @component.formulation_file.purge
-        @error_list = @component.errors.messages[:formulation_file].map { |message| { text: message } }
+        @component.errors.messages[:formulation_file].map(&method(:add_error))
         render :new
       end
     else
-      @error_list.push(text: "No file selected")
+      add_error "No file selected"
       render :new
     end
   end
 
 private
+
+  def add_error error_message
+    @error_list.push(text: error_message, href: "#formulation_file")
+  end
 
   def set_models
     @error_list = []

--- a/cosmetics-web/app/views/formulation_upload/new.html.slim
+++ b/cosmetics-web/app/views/formulation_upload/new.html.slim
@@ -15,7 +15,7 @@
         p For each ingredient give the International Nomenclature of Cosmetic Ingredients (INCI) name.
         = form_with(url: responsible_person_notification_component_formulation_index_path( \
                 @responsible_person, @notification, @component), method: :post, multipart: true) do |form|
-            .govuk-form-group
+            .govuk-form-group class=("govuk-form-group--error" if @error_list.any?)
                 = form.label :formulation_file, "File type can be a ‘pdf', 'rtf' or ‘txt’.", class: "govuk-label"
                 = form.file_field :formulation_file,  class: "govuk-file-upload", \
                     accept: Component.allowed_types.map(&method(:get_filetype_extension)).join(",")

--- a/cosmetics-web/app/views/formulation_upload/new.html.slim
+++ b/cosmetics-web/app/views/formulation_upload/new.html.slim
@@ -17,6 +17,8 @@
                 @responsible_person, @notification, @component), method: :post, multipart: true) do |form|
             .govuk-form-group class=("govuk-form-group--error" if @error_list.any?)
                 = form.label :formulation_file, "File type can be a ‘pdf', 'rtf' or ‘txt’.", class: "govuk-label"
-                = form.file_field :formulation_file,  class: "govuk-file-upload", \
+                span#file-upload-error-message.govuk-error-message
+                    = @error_list.last[:text] if @error_list.any?
+                = form.file_field :formulation_file, class: "govuk-file-upload", \
                     accept: Component.allowed_types.map(&method(:get_filetype_extension)).join(",")
             = form.submit "Continue", class: "govuk-button"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

Show an error, highlighting the form when occurs an error while uploading a formulation file (e.g.: no file, wrong file type)

## Description
<!--- Describe your changes in detail -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
