### PR TITLE
MSPSDS-6: Fix missing credentials on cosmetics-worker

### DIFF
--- a/cosmetics-worker/manifest.yml
+++ b/cosmetics-worker/manifest.yml
@@ -15,8 +15,8 @@ applications:
     - cosmetics-elasticsearch
     - cosmetics-queue
     - opss-log-drain
+    - antivirus-auth-env
     - cosmetics-aws-env
     - cosmetics-notify-env
     - cosmetics-rails-env
     - cosmetics-sentry-env
-

--- a/mspsds-worker/manifest.yml
+++ b/mspsds-worker/manifest.yml
@@ -20,4 +20,3 @@ applications:
     - mspsds-notify-env
     - mspsds-rails-env
     - mspsds-sentry-env
-


### PR DESCRIPTION
## Description
The cosmetics-worker manifest was missing the antivirus details

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Automated checks are passing locally.
- [x] CHANGELOG updated if change is worth telling users about.
