### PR TITLE
MSPSDS-997: Make assignee and description migration not update timestamps

### DIFF
--- a/psd-web/db/migrate/20190321122934_populate_assignee_and_description.rb
+++ b/psd-web/db/migrate/20190321122934_populate_assignee_and_description.rb
@@ -3,7 +3,7 @@ class PopulateAssigneeAndDescription < ActiveRecord::Migration[5.2]
     Investigation.all.each do |i|
       i.description = i.description || i.reason_created
       i.assignee = i.assignee || i.source.user
-      i.save
+      i.save(touch: false)
     end
   end
 end


### PR DESCRIPTION
So that the cases don't get 'updated_at' changed to 'the last time we deployed'