### PR TITLE
MSPSDS-615: shared-web-dev updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -60,3 +60,11 @@ update_configs:
     - dependencies
     - ruby
     - fixme
+
+  - package_manager: "ruby:bundler"
+    directory: "/shared-web/dev"
+    update_schedule: "live"
+    default_labels:
+    - dependencies
+    - ruby
+    - fixme

--- a/psd-web/vendor/shared-web/dev/shared-web-dev.gemspec
+++ b/psd-web/vendor/shared-web/dev/shared-web-dev.gemspec
@@ -1,1 +1,1 @@
-../../../shared-web/dev/shared-web-dev.gemspec
+../../../../shared-web/dev/shared-web-dev.gemspec


### PR DESCRIPTION
## Description
The `psd-web` symlink to `shared-web-dev.gemspec` was broken during the rename. We should also be checking the shared dev dependencies using dependabot.