### PR TITLE
MSPSDS-997: Fix ts case summary bug

### DIFF
--- a/psd-web/app/controllers/investigations/ts_investigations_controller.rb
+++ b/psd-web/app/controllers/investigations/ts_investigations_controller.rb
@@ -218,8 +218,11 @@ private
 
     case step
     when :why_reporting
+      params[:investigation][:hazard_description] = nil unless params[:investigation][:unsafe] == "1"
+      params[:investigation][:hazard_type] = nil unless params[:investigation][:unsafe] == "1"
+      params[:investigation][:non_compliant_reason] = nil unless params[:investigation][:non_compliant] == "1"
       params.require(:investigation).permit(
-        :unsafe, :hazard, :hazard_type, :hazard_description, :non_compliant, :non_compliant_reason
+        :unsafe, :hazard_type, :hazard_description, :non_compliant, :non_compliant_reason
       )
     when :reference_number
       params.require(:investigation).permit(:complainant_reference)

--- a/psd-web/app/views/investigations/edit_summary.html.slim
+++ b/psd-web/app/views/investigations/edit_summary.html.slim
@@ -1,11 +1,12 @@
-- content_for :page_title, "Update status"
+- content_for :page_title, "Update summary"
 - content_for :after_header do
   = link_to "Back to #{@investigation.pretty_description}", @investigation, class: "govuk-back-link"
 = form_with(model: @investigation, url: edit_summary_investigation_path(@investigation)) do |form|
   .govuk-grid-row
     .govuk-grid-column-two-thirds-from-desktop
       = render "form_components/govuk_error_summary", form: form
-      = render "minimal_investigation_heading", investigation: @investigation, title: "Edit case summary"
+      = render "minimal_investigation_heading", investigation: @investigation,
+              title: "Edit #{@investigation.case_type} summary"
       = render "form_components/govuk_textarea", key: :description, form: form,
               attributes: { maxlength: 10000 },
               label: { text: "Edit summary", classes: "govuk-visually-hidden" }


### PR DESCRIPTION
Make sure we don't store any hazard or non-compliance details if box isn't ticked

If a box is ticked, details filled, and then un-ticked, we still store those 'un-ticked' details on investigation. Which is surfaced in case description. 