### PR TITLE
PSD-1150: Fix crash when investigation has multiple correspondence types

### DIFF
--- a/psd-web/app/helpers/investigations/display_text_helper.rb
+++ b/psd-web/app/helpers/investigations/display_text_helper.rb
@@ -63,7 +63,7 @@ module Investigations::DisplayTextHelper
     # If a result in its entirety appears in case correspondence that the user can see,
     # we probably don't care what was its source.
     investigation.correspondences.each do |c|
-      return false if (c.send(key).include? sanitized_content) && c.can_be_displayed?
+      return false if (c.send(key)&.include? sanitized_content) && c.can_be_displayed?
     end
     true
   end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
This was breaking search if an investigation had multiple correspondence types. As we could be calling `include?` on `nil` (e,g, when trying to get `email_subject` on a phone call)

## Checklist:
- [x] Automated checks are passing locally.
- [x] CHANGELOG updated if change is worth telling users about.
