### PR TITLE
COSBETA-239: Map submit and search hostnames to app in deploy script

### DIFF
--- a/cosmetics-web/deploy.sh
+++ b/cosmetics-web/deploy.sh
@@ -9,23 +9,27 @@ set -ex
 #
 # SPACE: the space to which you want to deploy
 
-DOMAIN=submit-cosmetic-product-notifications.service.gov.uk
+DOMAIN=cosmetic-product-notifications.service.gov.uk
 if [[ $SPACE == "prod" ]]; then
-    HOSTNAME=www
+    SUBMIT_HOSTNAME=submit
+    SEARCH_HOSTNAME=search
 else
-    HOSTNAME=$SPACE
+    SUBMIT_HOSTNAME=$SPACE-submit
+    SEARCH_HOSTNAME=$SPACE-search
 fi
 APP=cosmetics-web
 APP_PREEXISTS=$(cf app $APP && echo 0 || echo 1)
 
 if [[ $APP_PREEXISTS ]]; then
     # We should deploy to a temporary location such that we can do a blue-green deployment
-    NEW_HOSTNAME=$HOSTNAME-temp
+    NEW_SUBMIT_HOSTNAME=$SUBMIT_HOSTNAME-temp
+    NEW_SEARCH_HOSTNAME=$SEARCH_HOSTNAME-temp
     NEW_APP=$APP-temp
 else
     # We don't need to deploy to a temporary location
     echo "No existing app found. Performing first-time setup."
-    NEW_HOSTNAME=$HOSTNAME
+    NEW_SUBMIT_HOSTNAME=$SUBMIT_HOSTNAME
+    NEW_SEARCH_HOSTNAME=$SEARCH_HOSTNAME
     NEW_APP=$APP
 fi
 
@@ -36,9 +40,10 @@ cp -a ./infrastructure/env/. ./cosmetics-web/env/
 rm -rf ./cosmetics-web/vendor/shared-web/
 cp -a ./shared-web/. ./cosmetics-web/vendor/shared-web/
 
-# Deploy the new app and set the hostname
-cf push $NEW_APP -f ./cosmetics-web/manifest.yml -d $DOMAIN --hostname $NEW_HOSTNAME --no-start
-cf set-env $NEW_APP COSMETICS_HOST "https://$NEW_HOSTNAME.$DOMAIN"
+# Deploy the new app, set the hostnames and start the app
+cf push $NEW_APP -f ./cosmetics-web/manifest.yml -d $DOMAIN --hostname $NEW_SUBMIT_HOSTNAME --no-start
+cf set-env $NEW_APP COSMETICS_HOST "$NEW_SUBMIT_HOSTNAME.$DOMAIN"
+cf map-route $NEW_APP $DOMAIN --hostname $NEW_SEARCH_HOSTNAME
 
 # Increase the assigned memory for staging
 cf scale $NEW_APP -f -m 2G
@@ -55,21 +60,25 @@ fi
 
 # TODO smoke test or manual confirmation?
 
-# Unmap the temporary hostname from the new app
-cf unmap-route $NEW_APP $DOMAIN --hostname $NEW_HOSTNAME
+# Unmap the temporary hostname(s) from the new app
+cf unmap-route $NEW_APP $DOMAIN --hostname $NEW_SUBMIT_HOSTNAME
+cf unmap-route $NEW_APP $DOMAIN --hostname $NEW_SEARCH_HOSTNAME
 
 # Remove basic auth if we're deploying to production
-if [[ $SPACE == "prod" ]]; then
-    cf unbind-service $NEW_APP cosmetics-auth-env
-fi
+# TODO COSBETA-240 Uncomment when service goes live
+#if [[ $SPACE == "prod" ]]; then
+#    cf unbind-service $NEW_APP cosmetics-auth-env
+#fi
 
-# Map the live hostname to the new app
-cf set-env $NEW_APP COSMETICS_HOST "https://$HOSTNAME.$DOMAIN"
+# Map the live hostnames to the new app
+cf set-env $NEW_APP COSMETICS_HOST "$SUBMIT_HOSTNAME.$DOMAIN"
 cf restart $NEW_APP
-cf map-route $NEW_APP $DOMAIN --hostname $HOSTNAME
+cf map-route $NEW_APP $DOMAIN --hostname $SUBMIT_HOSTNAME
+cf map-route $NEW_APP $DOMAIN --hostname $SEARCH_HOSTNAME
 
-# Unmap the live hostanme from the old app
-cf unmap-route $APP $DOMAIN --hostname $HOSTNAME
+# Unmap the live hostnames from the old app
+cf unmap-route $APP $DOMAIN --hostname $SUBMIT_HOSTNAME
+cf unmap-route $APP $DOMAIN --hostname $SEARCH_HOSTNAME
 
 # Remove the old app and rename the new one
 cf delete -f $APP

--- a/psd-web/deploy.sh
+++ b/psd-web/deploy.sh
@@ -38,7 +38,7 @@ cp -a ./shared-web/. ./psd-web/vendor/shared-web/
 
 # Deploy the new app and set the hostname
 cf push $NEW_APP -f ./psd-web/manifest.yml -d $DOMAIN --hostname $NEW_HOSTNAME --no-start
-cf set-env $NEW_APP PSD_HOST "https://$NEW_HOSTNAME.$DOMAIN"
+cf set-env $NEW_APP PSD_HOST "$NEW_HOSTNAME.$DOMAIN"
 
 # Increase the assigned memory for staging
 cf scale $NEW_APP -f -m 2G
@@ -64,7 +64,7 @@ if [[ $SPACE == "prod" ]]; then
 fi
 
 # Map the live hostname to the new app
-cf set-env $NEW_APP PSD_HOST "https://$HOSTNAME.$DOMAIN"
+cf set-env $NEW_APP PSD_HOST "$HOSTNAME.$DOMAIN"
 cf restart $NEW_APP
 cf map-route $NEW_APP $DOMAIN --hostname $HOSTNAME
 


### PR DESCRIPTION
## Description
Update the deploy script for `cosmetics-web` to map both the "submit" and "search" subdomains to the app (prefixed by the space name, e.g. `int-submit.cosmetic-...` and `int-search.cosmetic-...`).