### PR TITLE
COSBETA-248: Display nanomaterials for both pre- and post-EU Exit notifications

### DIFF
--- a/cosmetics-web/app/views/notifications/_component_details.html.slim
+++ b/cosmetics-web/app/views/notifications/_component_details.html.slim
@@ -5,22 +5,22 @@
     td.govuk-table__cell
       = render "none_or_bullet_list", entities_list: component.cmrs.map(&:display_name)
 
+tr.govuk-table__row
+  th.govuk-table__header[scope="row"]
+    | Nanomaterials
+  td.govuk-table__cell
+    = render "none_or_bullet_list", entities_list: component.nano_material&.nano_elements&.map(&:display_name)
+- if component.nano_material&.nano_elements.present?
   tr.govuk-table__row
     th.govuk-table__header[scope="row"]
-      | Nanomaterials
+      | Application instruction
     td.govuk-table__cell
-      = render "none_or_bullet_list", entities_list: component.nano_material&.nano_elements&.map(&:display_name)
-  - if component.nano_material&.nano_elements.present?
-    tr.govuk-table__row
-      th.govuk-table__header[scope="row"]
-        | Application instruction
-      td.govuk-table__cell
-        = component.nano_material.exposure_route
-    tr.govuk-table__row
-      th.govuk-table__header[scope="row"]
-        | Exposure condition
-      td.govuk-table__cell
-        = component.nano_material.exposure_condition
+      = component.nano_material.exposure_route
+  tr.govuk-table__row
+    th.govuk-table__header[scope="row"]
+      | Exposure condition
+    td.govuk-table__cell
+      = component.nano_material.exposure_condition
 
 tr.govuk-table__row
   th.govuk-table__header[scope="row"]

--- a/cosmetics-web/app/views/notifications/_substances_details.html.slim
+++ b/cosmetics-web/app/views/notifications/_substances_details.html.slim
@@ -6,11 +6,12 @@ h2.govuk-heading-l.poison-centre__table-heading
     - if component.name.present?
       caption.govuk-table__caption.govuk-heading-m
         = component.name
-    tr.govuk-table__row
-      th.govuk-table__header[class="govuk-!-width-one-half" scope="row"]
-        | CMR
-      td.govuk-table__cell
-        = render "none_or_bullet_list", entities_list: component.cmrs.map(&:display_name)
+    -if @notification.notified_post_eu_exit?
+      tr.govuk-table__row
+        th.govuk-table__header[class="govuk-!-width-one-half" scope="row"]
+          | CMR
+        td.govuk-table__cell
+          = render "none_or_bullet_list", entities_list: component.cmrs.map(&:display_name)
     tr.govuk-table__row
       th.govuk-table__header[class="govuk-!-width-one-half" scope="row"]
         | Nanomaterials

--- a/cosmetics-web/app/views/notifications/_substances_details.html.slim
+++ b/cosmetics-web/app/views/notifications/_substances_details.html.slim
@@ -6,7 +6,7 @@ h2.govuk-heading-l.poison-centre__table-heading
     - if component.name.present?
       caption.govuk-table__caption.govuk-heading-m
         = component.name
-    -if @notification.notified_post_eu_exit?
+    -if notification.notified_post_eu_exit?
       tr.govuk-table__row
         th.govuk-table__header[class="govuk-!-width-one-half" scope="row"]
           | CMR

--- a/cosmetics-web/app/views/poison_centres/notifications/show_poison_centre.html.slim
+++ b/cosmetics-web/app/views/poison_centres/notifications/show_poison_centre.html.slim
@@ -21,7 +21,6 @@
     = render "poison_centres/notifications/poison_centre_trigger_rule_formulation", notification: @notification
     = render "notifications/ingredient_details", notification: @notification
     = render "notifications/frame_formulation_details", notification: @notification
-    -if @notification.notified_post_eu_exit?
-      = render "notifications/substances_details", notification: @notification
+    = render "notifications/substances_details", notification: @notification
     = render "/notifications/responsible_person_details", responsible_person: @notification.responsible_person
     = render "/notifications/contact_person_details", contact_person: @notification.responsible_person


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Automated checks are passing locally.
- [ ] CHANGELOG updated if change is worth telling users about.
### General testing
- [ ] Test without javascript
- [ ] Test on small screen
### Accessibility testing
- [ ] Works keyboard only
- [ ] Tested with one screen reader
- [ ] Zoom page to 400% - content still visible
- [ ] Disable css - does content make sense and appear in a logical order?
- [ ] Passes automated checker (automated in build or manual)
