### PR TITLE
COSBETA-158 Prevent users from editing submitted notifications

### DIFF
--- a/cosmetics-web/app/controllers/additional_information_controller.rb
+++ b/cosmetics-web/app/controllers/additional_information_controller.rb
@@ -20,6 +20,6 @@ private
 
   def set_notification
     @notification = Notification.find_by reference_number: params[:notification_reference_number]
-    authorize @notification, policy_class: ResponsiblePersonNotificationPolicy
+    authorize @notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
   end
 end

--- a/cosmetics-web/app/controllers/component_build_controller.rb
+++ b/cosmetics-web/app/controllers/component_build_controller.rb
@@ -71,7 +71,7 @@ private
 
   def set_component
     @component = Component.find(params[:component_id])
-    authorize @component.notification, policy_class: ResponsiblePersonNotificationPolicy
+    authorize @component.notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
   end
 
   def component_params

--- a/cosmetics-web/app/controllers/formulation_upload_controller.rb
+++ b/cosmetics-web/app/controllers/formulation_upload_controller.rb
@@ -32,6 +32,6 @@ private
     @component = Component.find(params[:component_id])
     @notification = @component.notification
     @responsible_person = @notification.responsible_person
-    authorize @component.notification, policy_class: ResponsiblePersonNotificationPolicy
+    authorize @component.notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
   end
 end

--- a/cosmetics-web/app/controllers/notification_build_controller.rb
+++ b/cosmetics-web/app/controllers/notification_build_controller.rb
@@ -60,7 +60,7 @@ private
 
   def set_notification
     @notification = Notification.find_by reference_number: params[:notification_reference_number]
-    authorize @notification, policy_class: ResponsiblePersonNotificationPolicy
+    authorize @notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
   end
 
   def set_countries

--- a/cosmetics-web/app/controllers/product_image_upload_controller.rb
+++ b/cosmetics-web/app/controllers/product_image_upload_controller.rb
@@ -14,7 +14,9 @@ class ProductImageUploadController < ApplicationController
       if @notification.save
         redirect_to responsible_person_notification_additional_information_index_path(@notification.responsible_person, @notification)
       else
-        @notification.errors.messages[:image_upload].map(&method(:add_error))
+        @notification.image_uploads.each do |image_upload|
+          image_upload.errors.messages[:file].map(&method(:add_error))
+        end
         render :new
       end
     else
@@ -33,6 +35,6 @@ private
     @error_list = []
     @notification = Notification.find_by reference_number: params[:notification_reference_number]
     @responsible_person = @notification.responsible_person
-    authorize @notification, policy_class: ResponsiblePersonNotificationPolicy
+    authorize @notification, :update?, policy_class: ResponsiblePersonNotificationPolicy
   end
 end

--- a/cosmetics-web/app/policies/responsible_person_notification_policy.rb
+++ b/cosmetics-web/app/policies/responsible_person_notification_policy.rb
@@ -16,7 +16,7 @@ class ResponsiblePersonNotificationPolicy < ApplicationPolicy
   end
 
   def update?
-    user_member_of_associated_responsible_person?
+    user_member_of_associated_responsible_person? && notification_is_not_submitted?
   end
 
   def confirm?
@@ -35,5 +35,9 @@ private
 
   def user_member_of_associated_responsible_person?
     user.responsible_persons.include?(record&.responsible_person)
+  end
+
+  def notification_is_not_submitted?
+    !record&.notification_complete?
   end
 end

--- a/cosmetics-web/spec/controllers/additional_information_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/additional_information_controller_spec.rb
@@ -45,5 +45,12 @@ RSpec.describe AdditionalInformationController, type: :controller do
       get :index, params: { responsible_person_id: responsible_person.id, notification_reference_number: notification.reference_number }
       expect(response).to redirect_to(new_responsible_person_notification_product_image_upload_path(responsible_person, notification))
     end
+
+    it "raised a NotAuthorizedError if the notification has already been submitted" do
+      notification = Notification.create(responsible_person_id: responsible_person.id, components: [predefined_component], state: "notification_complete")
+      expect {
+        get :index, params: { responsible_person_id: responsible_person.id, notification_reference_number: notification.reference_number }
+      }.to raise_error(Pundit::NotAuthorizedError)
+    end
   end
 end

--- a/cosmetics-web/spec/controllers/component_build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/component_build_controller_spec.rb
@@ -60,6 +60,13 @@ RSpec.describe ComponentBuildController, type: :controller do
         get(:show, params: other_responsible_person_params.merge(id: :number_of_shades))
       }.to raise_error(Pundit::NotAuthorizedError)
     end
+
+    it "does not allow the user to update a notification component that has already been submitted" do
+      notification.update state: "notification_complete"
+      expect {
+        get(:show, params: params.merge(id: :number_of_shades))
+      }.to raise_error(Pundit::NotAuthorizedError)
+    end
   end
 
   describe "POST #update" do
@@ -106,6 +113,13 @@ RSpec.describe ComponentBuildController, type: :controller do
     it "does not allow the user to update a notification component for a Responsible Person they not belong to" do
       expect {
         post(:update, params: other_responsible_person_params.merge(id: :add_shades, component: { shades: %w[red blue] }))
+      }.to raise_error(Pundit::NotAuthorizedError)
+    end
+
+    it "does not allow the user to update a notification that has already been submitted" do
+      notification.update state: "notification_complete"
+      expect {
+        post(:update, params: params.merge(id: :add_shades, component: { shades: %w[red blue] }))
       }.to raise_error(Pundit::NotAuthorizedError)
     end
   end

--- a/cosmetics-web/spec/controllers/notification_build_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/notification_build_controller_spec.rb
@@ -56,6 +56,13 @@ RSpec.describe NotificationBuildController, type: :controller do
         get(:show, params: other_responsible_person_params.merge(id: :add_product_name))
       }.to raise_error(Pundit::NotAuthorizedError)
     end
+
+    it "does not allow the user to update a notification that has already been submitted" do
+      notification.update state: "notification_complete"
+      expect {
+        get(:show, params: params.merge(id: :add_product_name))
+      }.to raise_error(Pundit::NotAuthorizedError)
+    end
   end
 
   describe "POST #update" do
@@ -129,6 +136,13 @@ RSpec.describe NotificationBuildController, type: :controller do
     it "does not allow the user to update a notification for a Responsible Person they not belong to" do
       expect {
         post(:update, params: other_responsible_person_params.merge(id: :add_product_name, notification: { product_name: "Super Shampoo" }))
+      }.to raise_error(Pundit::NotAuthorizedError)
+    end
+
+    it "does not allow the user to update a notification that has already been submitted" do
+      notification.update state: "notification_complete"
+      expect {
+        post(:update, params: params.merge(id: :add_product_name, notification: { product_name: "Super Shampoo" }))
       }.to raise_error(Pundit::NotAuthorizedError)
     end
   end

--- a/cosmetics-web/spec/controllers/product_image_upload_controller_spec.rb
+++ b/cosmetics-web/spec/controllers/product_image_upload_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe FormulationUploadController, type: :controller do
+RSpec.describe ProductImageUploadController, type: :controller do
   let(:responsible_person) { create(:responsible_person) }
   let(:notification) { create(:notification, responsible_person: responsible_person) }
   let(:component) { create(:component, notification: notification) }
@@ -35,9 +35,9 @@ RSpec.describe FormulationUploadController, type: :controller do
   end
 
   describe "GET #new" do
-    it "assigns the correct component model" do
+    it "assigns the correct notification model" do
       get(:new, params: params)
-      expect(assigns(:component)).to eq(component)
+      expect(assigns(:notification)).to eq(notification)
     end
 
     it "does not let the user view the page for a component for a responsible person they do not belong to" do
@@ -48,9 +48,9 @@ RSpec.describe FormulationUploadController, type: :controller do
   end
 
   describe "POST #create" do
-    it "assigns the correct component model" do
+    it "assigns the correct notification model" do
       post(:create, params: params)
-      expect(assigns(:component)).to eq(component)
+      expect(assigns(:notification)).to eq(notification)
     end
 
     it "adds an error if no file uploaded" do
@@ -64,30 +64,30 @@ RSpec.describe FormulationUploadController, type: :controller do
     end
 
     it "adds errors from the component model to the errors list" do
-      post(:create, params: params.merge(formulation_file: image_file))
+      post(:create, params: params.merge(image_upload: [text_file]))
       expect(assigns(:error_list).length).to eq(1)
     end
 
-    it "adds the formulation file to the component when the uploaded file is valid" do
-      post(:create, params: params.merge(formulation_file: text_file))
-      expect(component.reload.formulation_file.attached?).to be true
+    it "adds the product image to the notification when the uploaded file is valid" do
+      post(:create, params: params.merge(image_upload: [image_file]))
+      expect(notification.image_uploads.length).to eq(1)
     end
 
     it "redirects to the additional information controller when the uploaded file is valid" do
-      post(:create, params: params.merge(formulation_file: text_file))
+      post(:create, params: params.merge(image_upload: [image_file]))
       expect(response).to redirect_to(responsible_person_notification_additional_information_index_path(responsible_person, notification))
     end
 
     it "does not let the user submit the form for a component for a responsible person they do not belong to" do
       expect {
-        post(:create, params: other_responsible_person_params.merge(formulation_file: text_file))
+        post(:create, params: other_responsible_person_params.merge(image_upload: [image_file]))
       }.to raise_error(Pundit::NotAuthorizedError)
     end
 
     it "does not let the user submit the form for a component for a completed notification" do
       notification.update state: "notification_complete"
       expect {
-        post(:create, params: params.merge(formulation_file: text_file))
+        post(:create, params: params.merge(image_upload: [image_file]))
       }.to raise_error(Pundit::NotAuthorizedError)
     end
   end


### PR DESCRIPTION
Prevents users from updating notifications once they've been submitted, either via replacing IDs in manual journey routes or the product for formulation upload pages.