### PR TITLE
PSD-1125: Use single name field on User model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ All notable changes to this project will be documented in this file.
 <!-- ### Cosmetics -->
 
 ### Next release checklist
-- [ ] Update cosmetics-app's name in keycloak
+- [ ] Update `cosmetics-app` name in keycloak
      1. Log into keycloak admin app, click on `Clients` and select `cosmetics-app`
          1. In the `Settings` tab, change the `Name` field to `Submit cosmetic product notifications`
          2. Press the `Save` button, to apply the changes
+- [ ] Update all user accounts to use the `First Name` field for full name
+     1. Log into the Keycloak admin app, click on the `Users` tab and select `View all users`
+     2. Edit each user and ensure the `First Name` field contains their full name
+     3. Set the `Last Name` field to `n/a` to indicate it is not used
 
 ## 2019-04-03
 ### Product safety database

--- a/cosmetics-web/app/controllers/responsible_persons/account_wizard_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/account_wizard_controller.rb
@@ -87,7 +87,7 @@ private
       @contact_person.email_address,
       @contact_person.name,
       @responsible_person.name,
-      User.current.full_name
+      User.current.name
     ).deliver_later
   end
 

--- a/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/team_members_controller.rb
@@ -13,7 +13,7 @@ class ResponsiblePersons::TeamMembersController < ApplicationController
       return redirect_to new_responsible_person_team_member_path(@responsible_person, user_already_exists: true)
     end
 
-    NotifyMailer.send_responsible_person_invite_email(@responsible_person.id, @responsible_person.name, team_member_params[:email_address], User.current.full_name).deliver_later
+    NotifyMailer.send_responsible_person_invite_email(@responsible_person.id, @responsible_person.name, team_member_params[:email_address], User.current.name).deliver_later
     redirect_to responsible_person_team_members_path(@responsible_person)
   end
 

--- a/cosmetics-web/app/controllers/responsible_persons/verification_controller.rb
+++ b/cosmetics-web/app/controllers/responsible_persons/verification_controller.rb
@@ -24,7 +24,7 @@ class ResponsiblePersons::VerificationController < ApplicationController
       @contact_person.email_address,
       @contact_person.name,
       @responsible_person.name,
-      User.current.full_name
+      User.current.name
 ).deliver_later
 
     redirect_to responsible_person_email_verification_keys_path(@responsible_person)

--- a/cosmetics-web/app/models/responsible_person_user.rb
+++ b/cosmetics-web/app/models/responsible_person_user.rb
@@ -2,8 +2,8 @@ class ResponsiblePersonUser < ApplicationRecord
   belongs_to :responsible_person
   belongs_to :user
 
-  def full_name
-    user&.full_name
+  def name
+    user&.name
   end
 
   def email_address

--- a/cosmetics-web/app/views/responsible_persons/team_members/index.html.slim
+++ b/cosmetics-web/app/views/responsible_persons/team_members/index.html.slim
@@ -30,7 +30,7 @@
         - @responsible_person.responsible_person_users.each do |user|
           tr.govuk-table__row
             td.govuk-table__cell
-              = user.full_name
+              = user.name
             td.govuk-table__cell
               = user.email_address
             td.govuk-table__cell

--- a/cosmetics-web/spec/factories/user.rb
+++ b/cosmetics-web/spec/factories/user.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     end
 
     id { SecureRandom.uuid }
-    first_name { "Test User" }
+    name { "Test User" }
     email { "test.user@example.com" }
 
     after :build do |user, options|

--- a/cosmetics-web/spec/login_helpers.rb
+++ b/cosmetics-web/spec/login_helpers.rb
@@ -26,6 +26,6 @@ module LoginHelpers
   end
 
   def format_user_for_get_userinfo(user, groups: [])
-    { sub: user[:id], email: user[:email], groups: groups, given_name: user[:first_name], family_name: user[:last_name] }.to_json
+    { sub: user[:id], email: user[:email], groups: groups, given_name: user[:name] }.to_json
   end
 end

--- a/cosmetics-web/spec/login_helpers.rb
+++ b/cosmetics-web/spec/login_helpers.rb
@@ -26,6 +26,6 @@ module LoginHelpers
   end
 
   def format_user_for_get_userinfo(user, groups: [])
-    { sub: user[:id], email: user[:email], groups: groups, given_name: user[:name] }.to_json
+    { sub: user[:id], email: user[:email], groups: groups, given_name: user[:name], family_name: "n/a" }.to_json
   end
 end

--- a/keycloak/configuration/initial-setup.json
+++ b/keycloak/configuration/initial-setup.json
@@ -1955,7 +1955,7 @@
     "totp" : false,
     "emailVerified" : true,
     "firstName" : "MSA User",
-    "lastName" : "",
+    "lastName" : "n/a",
     "email" : "msa@example.com",
     "credentials" : [ {
       "type" : "password",
@@ -1986,8 +1986,8 @@
     "enabled" : true,
     "totp" : false,
     "emailVerified" : true,
-    "firstName" : "Non-PSD",
-    "lastName" : "User",
+    "firstName" : "Non-PSD User",
+    "lastName" : "n/a",
     "email" : "non-psd@example.com",
     "credentials" : [ {
       "type" : "password",
@@ -2018,6 +2018,7 @@
     "totp" : false,
     "emailVerified" : true,
     "firstName" : "Poison Centre User",
+    "lastName" : "n/a",
     "email" : "poison.centre@example.com",
     "credentials" : [ {
       "type" : "password",
@@ -2084,13 +2085,13 @@
   }, {
     "id" : "eefa13c3-a47f-4199-9dc2-1c9d36af323b",
     "createdTimestamp" : 1536192541350,
-    "username" : "user@example.com",
+    "username" : "admin@example.com",
     "enabled" : true,
     "totp" : false,
     "emailVerified" : true,
     "firstName" : "Team Admin",
-    "lastName" : "User",
-    "email" : "user@example.com",
+    "lastName" : "n/a",
+    "email" : "admin@example.com",
     "credentials" : [ {
       "type" : "password",
       "hashedSaltedValue" : "HCXH4zH0mvTter5NLZQy1q6EsoKRwFplx0Di8+m86pUl2cc/YyvN9bqpqZLhTuGla9VLPKuhsN5wroazRa+RTw==",
@@ -2115,13 +2116,13 @@
   }, {
     "id" : "dbbc495b-475e-419a-a151-2e61c6f9fdce",
     "createdTimestamp" : 1536192541350,
-    "username" : "user2@example.com",
+    "username" : "user@example.com",
     "enabled" : true,
     "totp" : false,
     "emailVerified" : true,
-    "firstName" : "Second Test",
-    "lastName" : "User",
-    "email" : "user2@example.com",
+    "firstName" : "Test User",
+    "lastName" : "n/a",
+    "email" : "user@example.com",
     "credentials" : [ {
       "type" : "password",
       "hashedSaltedValue" : "HCXH4zH0mvTter5NLZQy1q6EsoKRwFplx0Di8+m86pUl2cc/YyvN9bqpqZLhTuGla9VLPKuhsN5wroazRa+RTw==",

--- a/psd-web/app/controllers/teams_controller.rb
+++ b/psd-web/app/controllers/teams_controller.rb
@@ -58,10 +58,10 @@ private
   def invite_user(user)
     @team.add_user user.id
     email = NotifyMailer.user_added_to_team user.email,
-                                            name: user.full_name,
+                                            name: user.name,
                                             team_page_url: team_url(@team),
                                             team_name: @team.name,
-                                            inviting_team_member_name: User.current.full_name
+                                            inviting_team_member_name: User.current.name
     email.deliver_later
   end
 end

--- a/psd-web/app/models/activity.rb
+++ b/psd-web/app/models/activity.rb
@@ -44,13 +44,13 @@ class Activity < ApplicationRecord
   end
 
   def entities_to_notify
-    entities = users_to_notify.map { |user| { name: user.full_name, email: user.email } }
+    entities = users_to_notify.map { |user| { name: user.name, email: user.email } }
 
     teams_to_notify.each do |team|
       if team.team_recipient_email.present?
         entities << { name: team.name, email: team.team_recipient_email }
       else
-        users_from_team = team.users.map { |user| { name: user.full_name, email: user.email } }
+        users_from_team = team.users.map { |user| { name: user.name, email: user.email } }
         entities.concat(users_from_team)
       end
     end

--- a/psd-web/app/models/investigation.rb
+++ b/psd-web/app/models/investigation.rb
@@ -209,7 +209,7 @@ private
   def send_confirmation_email
     if User.current
       NotifyMailer.investigation_created(pretty_id,
-                                       User.current.full_name,
+                                       User.current.name,
                                        User.current.email,
                                        title,
                                        case_type).deliver_later

--- a/psd-web/app/models/user.rb
+++ b/psd-web/app/models/user.rb
@@ -63,7 +63,7 @@ class User < Shared::Web::User
   end
 
   def display_name(ignore_visibility_restrictions: false)
-    display_name = full_name
+    display_name = name
     can_display_teams = ignore_visibility_restrictions || (organisation.present? && organisation.id == User.current.organisation&.id)
     can_display_teams = can_display_teams && teams.any?
     membership_display = can_display_teams ? team_names : organisation&.name
@@ -79,7 +79,7 @@ class User < Shared::Web::User
     if organisation.present? && organisation.id != User.current.organisation&.id
       organisation.name
     else
-      full_name
+      name
     end
   end
 

--- a/psd-web/app/views/investigations/_current_status.html.slim
+++ b/psd-web/app/views/investigations/_current_status.html.slim
@@ -15,7 +15,7 @@
         th.govuk-table__header[scope="row"]
           span.govuk-caption-m[class="govuk-!-font-size-16"]
             | Assigned to
-          = investigation.assignee ? investigation.assignee.full_name.to_s : "Unassigned"
+          = investigation.assignee ? investigation.assignee.name.to_s : "Unassigned"
           - if investigation.assignee&.organisation.present?
             div[class="govuk-!-font-size-16"]
               = investigation.assignee.organisation.name

--- a/psd-web/app/views/teams/show.html.slim
+++ b/psd-web/app/views/teams/show.html.slim
@@ -9,10 +9,10 @@
       a.govuk-button role="button" href=invite_to_team_url Invite a team member
     h2.govuk-heading-m Team Members
     ul.govuk-list
-      - @team.users.sort_by(&:full_name).each do |user|
+      - @team.users.sort_by(&:name).each do |user|
         li.teams--user class="govuk-!-padding-top-3 govuk-!-padding-bottom-3 govuk-!-margin-0"
           h3.teams--user-contact
-            span.govuk-heading-s.teams--user-name = user.full_name
+            span.govuk-heading-s.teams--user-name = user.name
             '
             span.govuk-caption-m.teams--user-email = user.email
           - if user.is_team_admin?

--- a/psd-web/test/controllers/activities_controller_test.rb
+++ b/psd-web/test/controllers/activities_controller_test.rb
@@ -34,7 +34,7 @@ class ActivitiesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "adding a comment should trigger one round of notifications" do
-    user_two = User.find_by(last_name: "User_two")
+    user_two = User.find_by(name: "Test User_two")
     @investigation.update(assignee: user_two)
     mock_investigation_updated(who_will_be_notified: [user_two])
     post investigation_activities_path(@investigation), params: {
@@ -133,7 +133,7 @@ class ActivitiesControllerTest < ActionDispatch::IntegrationTest
     allow(result).to receive(:deliver_later)
     allow(NotifyMailer).to receive(:investigation_updated) do |_id, user_name, _user_email, _text|
       @number_of_notifications += 1
-      assert_includes who_will_be_notified.map(&:full_name), user_name
+      assert_includes who_will_be_notified.map(&:name), user_name
       result
     end
   end

--- a/psd-web/test/controllers/investigations_controller_test.rb
+++ b/psd-web/test/controllers/investigations_controller_test.rb
@@ -2,15 +2,15 @@ require "test_helper"
 
 class InvestigationsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    mock_out_keycloak_and_notify(last_name: "User_four")
+    mock_out_keycloak_and_notify(name: "User_four")
 
-    @assignee = User.find_by(last_name: "User_one")
-    @non_opss_user = User.find_by(last_name: "User_two")
+    @assignee = User.find_by(name: "Test User_one")
+    @non_opss_user = User.find_by(name: "Test User_two")
     mock_user_as_non_opss(@non_opss_user)
 
     @investigation_one = load_case(:one)
     @investigation_one.created_at = Time.zone.parse('2014-07-11 21:00')
-    @investigation_one.assignee = User.find_by(last_name: "User_four")
+    @investigation_one.assignee = User.find_by(name: "Test User_four")
     @investigation_one.source = sources(:investigation_one)
     @investigation_one.save
 

--- a/psd-web/test/controllers/team_test.rb
+++ b/psd-web/test/controllers/team_test.rb
@@ -4,10 +4,10 @@ class TeamTest < ActionDispatch::IntegrationTest
   setup do
     mock_out_keycloak_and_notify
 
-    @user_one = User.find_by(last_name: "User_one")
-    @user_two = User.find_by(last_name: "User_two")
-    @user_three = User.find_by(last_name: "User_three")
-    @user_four = User.find_by(last_name: "User_four")
+    @user_one = User.find_by(name: "Test User_one")
+    @user_two = User.find_by(name: "Test User_two")
+    @user_three = User.find_by(name: "Test User_three")
+    @user_four = User.find_by(name: "Test User_four")
 
     prepare_assigned_cases
   end

--- a/psd-web/test/models/investigation_test.rb
+++ b/psd-web/test/models/investigation_test.rb
@@ -183,18 +183,18 @@ class InvestigationTest < ActiveSupport::TestCase
 
   test "visible to creator organisation" do
     create_new_private_case
-    creator = User.find_by(last_name: "User_one")
+    creator = User.find_by(name: "Test User_one")
     mock_user_as_non_opss(creator)
-    user = User.find_by(last_name: "User_two")
+    user = User.find_by(name: "Test User_two")
     mock_user_as_non_opss(user)
     assert_equal(policy(@new_investigation).show?(user: user), true)
   end
 
   test "visible to assignee organisation" do
     create_new_private_case
-    assignee = User.find_by(last_name: "User_two")
+    assignee = User.find_by(name: "Test User_two")
     mock_user_as_opss(assignee)
-    user = User.find_by(last_name: "User_three")
+    user = User.find_by(name: "Test User_three")
     mock_user_as_opss(user)
     @new_investigation.assignee = assignee
     assert(policy(@new_investigation).show?(user: user))
@@ -202,13 +202,13 @@ class InvestigationTest < ActiveSupport::TestCase
 
   test "not visible to no-source, no-assignee organisation" do
     create_new_private_case
-    sign_in_as User.find_by(last_name: "User_two")
+    sign_in_as User.find_by(name: "Test User_two")
     mock_user_as_non_opss(User.current)
     assert_not(policy(@new_investigation).show?(user: User.current))
   end
 
   test "past assignees should be computed" do
-    user = User.find_by(last_name: "User_one")
+    user = User.find_by(name: "Test User_one")
     @investigation.update(assignee: user)
     assert_includes @investigation.past_assignees, user
   end
@@ -221,26 +221,26 @@ class InvestigationTest < ActiveSupport::TestCase
 
   test "people out of current assignee's team should not be able to re-assign case" do
     investigation = create_new_case
-    investigation.assignee = User.find_by(last_name: "User_one")
-    assert_not policy(investigation).assign?(user: User.find_by(last_name: "User_three"))
+    investigation.assignee = User.find_by(name: "Test User_one")
+    assert_not policy(investigation).assign?(user: User.find_by(name: "Test User_three"))
   end
 
   test "people in current assignee's team should be able to re-assign case" do
     investigation = create_new_case
-    investigation.assignee = User.find_by(last_name: "User_one")
-    assert policy(investigation).assign?(user: User.find_by(last_name: "User_two"))
+    investigation.assignee = User.find_by(name: "Test User_one")
+    assert policy(investigation).assign?(user: User.find_by(name: "Test User_two"))
   end
 
   test "people out of currently assigned team should not be able to re-assign case" do
     investigation = create_new_case
     investigation.assignee = Team.find_by(name: "Team 1")
-    assert_not policy(investigation).assign?(user: User.find_by(last_name: "User_three"))
+    assert_not policy(investigation).assign?(user: User.find_by(name: "Test User_three"))
   end
 
   test "people in currently assigned team should be able to re-assign case" do
     investigation = create_new_case
     investigation.assignee = Team.find_by(name: "Team 1")
-    assert policy(investigation).assign?(user: User.find_by(last_name: "User_four"))
+    assert policy(investigation).assign?(user: User.find_by(name: "Test User_four"))
   end
 
   test "pretty_id should contain YYMM" do

--- a/psd-web/test/models/notification_test.rb
+++ b/psd-web/test/models/notification_test.rb
@@ -4,9 +4,9 @@ class NotificationTest < ActiveSupport::TestCase
   setup do
     mock_out_keycloak_and_notify
     @investigation = Investigation.create(description: "new investigation for notification test")
-    @user_one = User.find_by(last_name: "User_one")
-    @user_two = User.find_by(last_name: "User_two")
-    @user_three = User.find_by(last_name: "User_three")
+    @user_one = User.find_by(name: "Test User_one")
+    @user_two = User.find_by(name: "Test User_two")
+    @user_three = User.find_by(name: "Test User_three")
   end
 
   teardown do
@@ -43,7 +43,7 @@ class NotificationTest < ActiveSupport::TestCase
 
   test "should notify creator and assignee when case is closed or reopened by someone else" do
     @investigation.update(assignee: @user_three)
-    sign_in_as User.find_by(last_name: "User_four")
+    sign_in_as User.find_by(name: "Test User_four")
     mock_investigation_updated(who_will_be_notified: [@user_one, @user_three].map(&:email))
     @investigation.update(is_closed: !@investigation.is_closed)
     assert_equal 2, @number_of_notifications
@@ -143,7 +143,7 @@ class NotificationTest < ActiveSupport::TestCase
     allow(notify_mailer_return_value).to receive(:deliver_later)
     allow(NotifyMailer).to receive(:investigation_created) do |_id, user_name, _user_email, _investigation_title, _investigation_type|
       @number_of_notifications += 1
-      assert_includes who_will_be_notified.map(&:full_name), user_name
+      assert_includes who_will_be_notified.map(&:name), user_name
       notify_mailer_return_value
     end
   end

--- a/psd-web/test/models/user_test.rb
+++ b/psd-web/test/models/user_test.rb
@@ -3,8 +3,8 @@ require "test_helper"
 class UserTest < ActiveSupport::TestCase
   setup do
     mock_out_keycloak_and_notify
-    @user = User.find_by(last_name: "User_one")
-    @user_four = User.find_by(last_name: "User_four")
+    @user = User.find_by(name: "Test User_one")
+    @user_four = User.find_by(name: "Test User_four")
     mock_user_as_non_opss(@user)
     mock_user_as_opss(@user_four)
   end
@@ -46,6 +46,6 @@ class UserTest < ActiveSupport::TestCase
 
   test "don't load non-psd users" do
     User.all
-    assert_not User.find_by(last_name: "Non_psd_user")
+    assert_not User.find_by(name: "Test Non_psd_user")
   end
 end

--- a/psd-web/test/system/investigation_assignee_test.rb
+++ b/psd-web/test/system/investigation_assignee_test.rb
@@ -17,7 +17,7 @@ class InvestigationAssigneeTest < ApplicationSystemTestCase
     choose @user.display_name, visible: false
     click_on "Continue"
     click_on "Confirm change"
-    assert_text "Assigned to\n#{@user.full_name}\n#{@user.organisation.name}"
+    assert_text "Assigned to\n#{@user.name}\n#{@user.organisation.name}"
     click_on "Activity"
     assert_text "Assigned to #{@user.display_name}"
   end

--- a/psd-web/test/system/record_email_correspondence_test.rb
+++ b/psd-web/test/system/record_email_correspondence_test.rb
@@ -137,7 +137,7 @@ class RecordEmailCorrespondenceTest < ApplicationSystemTestCase
     click_button "Continue"
     click_button "Continue"
 
-    other_org_user = User.find_by last_name: "Ts_user"
+    other_org_user = User.find_by name: "Test Ts_user"
     sign_in_as other_org_user
     visit investigation_path(@investigation)
 
@@ -149,7 +149,7 @@ class RecordEmailCorrespondenceTest < ApplicationSystemTestCase
   end
 
   test "does not conceal consumer information from assignee" do
-    other_org_user = User.find_by last_name: "Ts_user"
+    other_org_user = User.find_by name: "Test Ts_user"
     set_investigation_assignee! @investigation, other_org_user
     fill_in_context_form
     choose :correspondence_email_has_consumer_info_true, visible: false
@@ -168,10 +168,10 @@ class RecordEmailCorrespondenceTest < ApplicationSystemTestCase
   end
 
   test "does not conceal consumer information from assignee's team" do
-    other_org_user = User.find_by last_name: "Ts_user"
+    other_org_user = User.find_by name: "Test Ts_user"
     sign_in_as other_org_user
-    assignee = User.find_by last_name: "User_one"
-    same_team_user = User.find_by last_name: "User_four"
+    assignee = User.find_by name: "Test User_one"
+    same_team_user = User.find_by name: "Test User_four"
 
     set_investigation_assignee! @investigation, assignee
     fill_in_context_form
@@ -198,7 +198,7 @@ class RecordEmailCorrespondenceTest < ApplicationSystemTestCase
     click_button "Continue"
     click_button "Continue"
 
-    same_org_user = User.find_by last_name: "User_three"
+    same_org_user = User.find_by name: "Test User_three"
     sign_in_as same_org_user
     visit investigation_path(@investigation)
 

--- a/psd-web/test/system/record_phonecall_correspondence_test.rb
+++ b/psd-web/test/system/record_phonecall_correspondence_test.rb
@@ -100,7 +100,7 @@ class RecordPhoneCallCorrespondenceTest < ApplicationSystemTestCase
     click_button "Continue"
     click_button "Continue"
 
-    other_org_user = User.find_by last_name: "Ts_user"
+    other_org_user = User.find_by name: "Test Ts_user"
     sign_in_as other_org_user
     visit investigation_path(@investigation)
 
@@ -112,7 +112,7 @@ class RecordPhoneCallCorrespondenceTest < ApplicationSystemTestCase
   end
 
   test "does not conceal consumer information from assignee" do
-    other_org_user = User.find_by last_name: "Ts_user"
+    other_org_user = User.find_by name: "Test Ts_user"
     set_investigation_assignee! @investigation, other_org_user
     fill_in_context_form
     choose :correspondence_phone_call_has_consumer_info_true, visible: false
@@ -131,10 +131,10 @@ class RecordPhoneCallCorrespondenceTest < ApplicationSystemTestCase
   end
 
   test "does not conceal consumer information from assignee's team" do
-    other_org_user = User.find_by last_name: "Ts_user"
+    other_org_user = User.find_by name: "Test Ts_user"
     sign_in_as other_org_user
-    assignee = User.find_by last_name: "User_one"
-    same_team_user = User.find_by last_name: "User_four"
+    assignee = User.find_by name: "Test User_one"
+    same_team_user = User.find_by name: "Test User_four"
 
     set_investigation_assignee! @investigation, assignee
     fill_in_context_form
@@ -161,7 +161,7 @@ class RecordPhoneCallCorrespondenceTest < ApplicationSystemTestCase
     click_button "Continue"
     click_button "Continue"
 
-    same_org_user = User.find_by last_name: "User_three"
+    same_org_user = User.find_by name: "Test User_three"
     sign_in_as same_org_user
     visit investigation_path(@investigation)
 

--- a/psd-web/test/test_helper.rb
+++ b/psd-web/test/test_helper.rb
@@ -45,7 +45,7 @@ class ActiveSupport::TestCase
   # On top of mocking out external services, this method also sets the user to an initial,
   # sensible value, but it should only be run once per test.
   # To change currently logged in user afterwards call `sign_in_as(...)`
-  def mock_out_keycloak_and_notify(last_name: "User_one")
+  def mock_out_keycloak_and_notify(name: "User_one")
     @users = [test_user(name: "User_four"),
               test_user(name: "User_one"),
               test_user(name: "User_two"),
@@ -67,7 +67,7 @@ class ActiveSupport::TestCase
     Team.all
     TeamUser.all
     User.all
-    sign_in_as User.find_by(last_name: last_name)
+    sign_in_as User.find_by(name: "Test #{name}")
     stub_notify_mailer
   end
 
@@ -154,7 +154,7 @@ private
     allow(@keycloak_client_instance).to receive(:has_role?).with(id, :team_admin).and_return(false)
     allow(@keycloak_client_instance).to receive(:has_role?).with(id, :psd_user).and_return(true)
     allow(@keycloak_client_instance).to receive(:has_role?).with(id, :opss_user).and_return(true) unless ts_user
-    { id: id, email: "#{name}@example.com", first_name: "Test", last_name: name }
+    { id: id, email: "#{name}@example.com", name: "Test #{name}" }
   end
 
   def non_psd_user(name:)
@@ -162,7 +162,7 @@ private
     allow(@keycloak_client_instance).to receive(:has_role?).with(id, :team_admin).and_return(false)
     allow(@keycloak_client_instance).to receive(:has_role?).with(id, :psd_user).and_return(false)
     allow(@keycloak_client_instance).to receive(:has_role?).with(id, :opss_user).and_return(false)
-    { id: id, email: "#{name}@example.com", first_name: "Test", last_name: name }
+    { id: id, email: "#{name}@example.com", name: "Test #{name}" }
   end
 
   def organisations
@@ -226,7 +226,7 @@ private
   end
 
   def format_user_for_get_users(users)
-    users.map { |user| { id: user[:id], email: user[:email], firstName: user[:first_name], lastName: user[:last_name] } }.to_json
+    users.map { |user| { id: user[:id], email: user[:email], firstName: user[:name] } }.to_json
   end
 
   def stub_user_management

--- a/psd-web/test/test_helper.rb
+++ b/psd-web/test/test_helper.rb
@@ -226,7 +226,7 @@ private
   end
 
   def format_user_for_get_users(users)
-    users.map { |user| { id: user[:id], email: user[:email], firstName: user[:name] } }.to_json
+    users.map { |user| { id: user[:id], email: user[:email], firstName: user[:name], lastName: "n/a" } }.to_json
   end
 
   def stub_user_management

--- a/shared-web/app/clients/shared/web/keycloak_client.rb
+++ b/shared-web/app/clients/shared/web/keycloak_client.rb
@@ -77,7 +77,7 @@ module Shared
         user_groups = all_user_groups(force: force)
 
         JSON.parse(response).map do |user|
-          { id: user["id"], email: user["email"], groups: user_groups[user["id"]], first_name: user["firstName"], last_name: user["lastName"] }
+          { id: user["id"], email: user["email"], groups: user_groups[user["id"]], name: user["firstName"] }
         end
       end
 
@@ -162,7 +162,7 @@ module Shared
       def user_info
         response = @client.get_userinfo
         user = JSON.parse(response)
-        { id: user["sub"], email: user["email"], groups: user["groups"], first_name: user["given_name"], last_name: user["family_name"] }
+        { id: user["sub"], email: user["email"], groups: user["groups"], name: user["given_name"] }
       end
 
       def has_role?(user_id, role)

--- a/shared-web/app/models/shared/web/user.rb
+++ b/shared-web/app/models/shared/web/user.rb
@@ -5,8 +5,7 @@ module Shared
 
       belongs_to :organisation
 
-      field :first_name
-      field :last_name
+      field :name
       field :email
 
       def self.find_or_create(user)
@@ -34,10 +33,6 @@ module Shared
 
       def self.current=(user)
         RequestStore.store[:current_user] = user
-      end
-
-      def full_name
-        "#{first_name} #{last_name}"
       end
 
       def has_role?(role)


### PR DESCRIPTION
The user's full name is stored on Keycloak as the "firstName" field. The "lastName" field is no longer used.